### PR TITLE
Update clawdbot-bedrock.yaml with ARM architecture detection for AWS CLI installation

### DIFF
--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -345,7 +345,12 @@ Resources:
           
           # Install AWS CLI v2
           echo "[2/9] Installing AWS CLI..."
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+          else
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          fi
           unzip -q awscliv2.zip
           ./aws/install
           rm -rf aws awscliv2.zip


### PR DESCRIPTION
*Issue #, if available:*
x86 version of AWS CLI is the only install option
*Description of changes:*
Update clawdbot-bedrock.yaml with ARM architecture detection for AWS CLI installation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
