### PR TITLE
Add Mac instance support

### DIFF
--- a/clawdbot-bedrock-mac.yaml
+++ b/clawdbot-bedrock-mac.yaml
@@ -325,11 +325,6 @@ Resources:
             CidrIp: !Ref AllowedSSHCIDR
             Description: "SSH access (fallback)"
           - !Ref AWS::NoValue
-        - IpProtocol: tcp
-          FromPort: 5900
-          ToPort: 5900
-          CidrIp: !Ref AllowedSSHCIDR
-          Description: "VNC access for Mac GUI"
       SecurityGroupEgress:
         - IpProtocol: -1
           CidrIp: "0.0.0.0/0"


### PR DESCRIPTION
*Summary*
Add clawdbot-bedrock-mac.yaml for mac instance support

*Description of changes:*
Support for Mac instance types: mac1.metal (Intel), mac2.metal (M1), mac2-m2.metal (M2), mac2-m2pro.metal (M2 Pro)
Automatic Dedicated Host provisioning (required for Mac instances)
Auto-detection of ARM64/x86 architecture for correct SSM Agent installation
launchd service for auto-starting Clawdbot gateway on boot
Pre-configured macOS AMI mappings for 7 regions (us-east-1, us-east-2, us-west-2, eu-west-1, eu-central-1, ap-southeast-1, ap-southeast-2)

*mac-specific-adaptions*
SSM Agent manual installation (not pre-installed on macOS)
Uses launchd instead of systemd for service management

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
