### PR TITLE
Make KeyPair and SSH inbound rules optional

### DIFF
--- a/clawdbot-bedrock-mac.yaml
+++ b/clawdbot-bedrock-mac.yaml
@@ -55,13 +55,14 @@ Parameters:
     Description: "macOS AMI ID - 'auto' uses region-specific AMI from Mappings, or specify custom AMI ID"
 
   KeyPairName:
-    Type: AWS::EC2::KeyPair::KeyName
-    Description: "EC2 key pair for emergency SSH access"
+    Type: String
+    Default: "none"
+    Description: "EC2 key pair for emergency SSH access (optional - set to 'none' to skip)"
 
   AllowedSSHCIDR:
     Type: String
-    Default: "0.0.0.0/0"
-    Description: "CIDR for SSH access (recommend SSM Session Manager, set to 127.0.0.1/32 to disable SSH)"
+    Default: ""
+    Description: "CIDR for SSH access (optional - leave empty for no inbound rules. SSM Session Manager is used for access. If SSH is needed, set to your IP/32 - find your IP at checkip.amazonaws.com)"
 
   CreateVPCEndpoints:
     Type: String
@@ -80,7 +81,10 @@ Parameters:
 
 Conditions:
   CreateEndpoints: !Equals [!Ref CreateVPCEndpoints, "true"]
-  AllowSSH: !Not [!Equals [!Ref AllowedSSHCIDR, "127.0.0.1/32"]]
+  HasKeyPair: !Not [!Equals [!Ref KeyPairName, "none"]]
+  AllowSSH: !And
+    - !Not [!Equals [!Ref AllowedSSHCIDR, ""]]
+    - !Not [!Equals [!Ref KeyPairName, "none"]]
   UseAppleSilicon: !Or
     - !Equals [!Ref MacInstanceType, "mac2.metal"]
     - !Equals [!Ref MacInstanceType, "mac2-m2.metal"]
@@ -325,11 +329,14 @@ Resources:
             CidrIp: !Ref AllowedSSHCIDR
             Description: "SSH access (fallback)"
           - !Ref AWS::NoValue
-        - IpProtocol: tcp
-          FromPort: 5900
-          ToPort: 5900
-          CidrIp: !Ref AllowedSSHCIDR
-          Description: "VNC access for Mac GUI"
+        - !If
+          - AllowSSH
+          - IpProtocol: tcp
+            FromPort: 5900
+            ToPort: 5900
+            CidrIp: !Ref AllowedSSHCIDR
+            Description: "VNC access for Mac GUI"
+          - !Ref AWS::NoValue
       SecurityGroupEgress:
         - IpProtocol: -1
           CidrIp: "0.0.0.0/0"
@@ -350,7 +357,7 @@ Resources:
           - !FindInMap [MacAMIMap, !Ref "AWS::Region", ARM64]
           - !FindInMap [MacAMIMap, !Ref "AWS::Region", x86]
       InstanceType: !Ref MacInstanceType
-      KeyName: !Ref KeyPairName
+      KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref "AWS::NoValue"]
       IamInstanceProfile: !Ref OpenClawInstanceProfile
       Tenancy: host
       HostId: !Ref MacDedicatedHost

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -48,13 +48,14 @@ Parameters:
       - "c5.xlarge"
 
   KeyPairName:
-    Type: AWS::EC2::KeyPair::KeyName
-    Description: "EC2 key pair for emergency SSH access"
+    Type: String
+    Default: "none"
+    Description: "EC2 key pair for emergency SSH access (optional - set to 'none' to skip)"
 
   AllowedSSHCIDR:
     Type: String
-    Default: "0.0.0.0/0"
-    Description: "CIDR for SSH access (recommend SSM Session Manager, set to 127.0.0.1/32 to disable SSH)"
+    Default: ""
+    Description: "CIDR for SSH access (optional - leave empty for no inbound rules. SSM Session Manager is used for access. If SSH is needed, set to your IP/32 - find your IP at checkip.amazonaws.com)"
 
   CreateVPCEndpoints:
     Type: String
@@ -73,7 +74,10 @@ Parameters:
 
 Conditions:
   CreateEndpoints: !Equals [!Ref CreateVPCEndpoints, "true"]
-  AllowSSH: !Not [!Equals [!Ref AllowedSSHCIDR, "127.0.0.1/32"]]
+  HasKeyPair: !Not [!Equals [!Ref KeyPairName, "none"]]
+  AllowSSH: !And
+    - !Not [!Equals [!Ref AllowedSSHCIDR, ""]]
+    - !Not [!Equals [!Ref KeyPairName, "none"]]
   UseGraviton: !Or
     - !Equals [!Select [0, !Split ['.', !Ref InstanceType]], 't4g']
     - !Equals [!Select [0, !Split ['.', !Ref InstanceType]], 'c7g']
@@ -309,7 +313,7 @@ Resources:
         - !Sub '{{resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id}}'
         - !Sub '{{resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id}}'
       InstanceType: !Ref InstanceType
-      KeyName: !Ref KeyPairName
+      KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref "AWS::NoValue"]
       IamInstanceProfile: !Ref OpenClawInstanceProfile
       NetworkInterfaces:
         - AssociatePublicIpAddress: true


### PR DESCRIPTION
## Summary
- **KeyPairName** changed from required (`AWS::EC2::KeyPair::KeyName`) to optional (`String`, default: `none`). EC2 `KeyName` property is omitted via `AWS::NoValue` when no key pair is provided.
- **AllowedSSHCIDR** default changed from `0.0.0.0/0` to empty string (no inbound rules by default). SSM Session Manager is the primary access method — SSH is now opt-in. Description updated to point users to `checkip.amazonaws.com` for finding their IP.
- **VNC ingress rule** (port 5900) in the Mac template is now also conditional on `AllowSSH`, so it's omitted when no key pair or CIDR is provided.
- Added `HasKeyPair` and updated `AllowSSH` conditions in both templates.

These changes allow users to deploy without creating an EC2 key pair first, reducing friction for one-click deployments. Access via SSM Session Manager works without any inbound rules.

## Test plan
- [ ] Deploy `clawdbot-bedrock.yaml` with default parameters (no key pair, no SSH CIDR) — verify no inbound rules on security group, instance launches without `KeyName`
- [ ] Deploy `clawdbot-bedrock.yaml` with a key pair and SSH CIDR — verify SSH inbound rule is created and `KeyName` is set
- [ ] Deploy `clawdbot-bedrock-mac.yaml` with default parameters — verify no SSH or VNC inbound rules
- [ ] Deploy `clawdbot-bedrock-mac.yaml` with a key pair and SSH CIDR — verify both SSH and VNC inbound rules are created
- [ ] Verify SSM Session Manager access works in all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)