### PR TITLE
docs: Fix ClawdbotModel to OpenClawModel parameter name

### DIFF
--- a/.kiro/steering/deploy-moltbot-conversationally.md
+++ b/.kiro/steering/deploy-moltbot-conversationally.md
@@ -814,7 +814,7 @@ aws cloudformation create-stack \
   --template-body file://clawdbot-bedrock.yaml \
   --parameters \
     ParameterKey=KeyPairName,ParameterValue=<KEY_NAME> \
-    ParameterKey=ClawdbotModel,ParameterValue=<MODEL_ID> \
+    ParameterKey=OpenClawModel,ParameterValue=<MODEL_ID> \
     ParameterKey=InstanceType,ParameterValue=<INSTANCE_TYPE> \
     ParameterKey=CreateVPCEndpoints,ParameterValue=<true/false> \
   --capabilities CAPABILITY_IAM \

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Cost: ~$0.01/request | Time: 2-5s | Security: Private network
 
 ```yaml
 # In CloudFormation parameters
-ClawdbotModel:
+OpenClawModel:
   - global.amazon.nova-2-lite-v1:0              # Default, most cost-effective
   - global.anthropic.claude-sonnet-4-5-20250929-v1:0  # Most capable
   - us.amazon.nova-pro-v1:0                     # Balanced performance

--- a/README_CN.md
+++ b/README_CN.md
@@ -392,7 +392,7 @@ EC2（Clawdbot）：
 ### 支持的模型
 
 ```yaml
-ClawdbotModel:
+OpenClawModel:
   - anthropic.claude-sonnet-4-5-20250929-v1:0  # 默认，最强能力
   - anthropic.claude-3-5-sonnet-20241022-v2:0  # 稳定备选
   - anthropic.claude-3-5-haiku-20241022-v1:0   # 更快，更便宜

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -517,7 +517,7 @@ aws cloudformation update-stack \
   --parameters \
     ParameterKey=InstanceType,ParameterValue=c7g.xlarge \
     ParameterKey=KeyPairName,UsePreviousValue=true \
-    ParameterKey=ClawdbotModel,UsePreviousValue=true \
+    ParameterKey=OpenClawModel,UsePreviousValue=true \
   --capabilities CAPABILITY_IAM \
   --region us-west-2
 ```


### PR DESCRIPTION
## Summary
Update documentation to match CloudFormation template parameter name.

## Problem
The CloudFormation templates use `OpenClawModel` but documentation referenced `ClawdbotModel`, causing deployment failures when users copy commands from the docs.

## Changes
- README.md
- README_CN.md  
- TROUBLESHOOTING.md
- .kiro/steering/deploy-moltbot-conversationally.md

All references to `ClawdbotModel` updated to `OpenClawModel`.