### PR TITLE
Add community backup skill integration docs

### DIFF
--- a/COMMUNITY_SKILLS.md
+++ b/COMMUNITY_SKILLS.md
@@ -1,0 +1,38 @@
+# Community Skills
+
+This repository can document useful third-party OpenClaw skills, but these are community-maintained integrations and are not part of the core AWS sample support surface.
+
+## Backup and Restore (S3 + optional KMS)
+
+- Skill repository: [genedragon/openclaw-aws-backup-skill](https://github.com/genedragon/openclaw-aws-backup-skill)
+- Purpose: encrypted backup/restore for OpenClaw workspaces and state using S3, with optional KMS.
+- Ownership: community-maintained (not maintained by `aws-samples`).
+
+### Quick start
+
+```bash
+cd /home/ubuntu/.openclaw/workspace
+git clone https://github.com/genedragon/openclaw-aws-backup-skill.git
+cd openclaw-aws-backup-skill
+npm install
+sudo npm link
+
+# first-time setup
+openclaw-aws-backup setup
+```
+
+### Common commands
+
+```bash
+openclaw-aws-backup create
+openclaw-aws-backup list
+openclaw-aws-backup restore
+openclaw-aws-backup test
+```
+
+### Security and operations notes
+
+- Use least-privilege IAM permissions for S3 and KMS.
+- Prefer KMS encryption for production backups.
+- Configure and review retention policies regularly.
+- Test restore paths before relying on backups in production.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ openclaw doesn't have official Lark/Feishu support, but the community has create
 
 Install on your EC2 instance to forward messages between Feishu and openclaw via WebSocket. No public IP or domain required.
 
+#### Community Skills
+
+Looking for optional third-party extensions? See [Community Skills](COMMUNITY_SKILLS.md).
+
+Featured: [openclaw-aws-backup-skill](https://github.com/genedragon/openclaw-aws-backup-skill) for S3 backup/restore with optional KMS encryption.
+
 ### Using openclaw
 
 #### Send Messages

--- a/README_AGENTCORE.md
+++ b/README_AGENTCORE.md
@@ -321,6 +321,12 @@ openclaw skills install voice-generation
 openclaw skills installed
 ```
 
+#### Community Skills
+
+For optional third-party integrations, see [Community Skills](COMMUNITY_SKILLS.md).
+
+Featured: [openclaw-aws-backup-skill](https://github.com/genedragon/openclaw-aws-backup-skill) for encrypted S3 backup/restore workflows.
+
 #### Custom Prompts
 
 Create `~/.openclaw/workspace/SOUL.md` on the instance:
@@ -588,4 +594,3 @@ This deployment template is provided as-is. OpenClaw itself is licensed under it
 ---
 
 **Deploy your personal AI assistant on AWS infrastructure you control with serverless agent execution.**
-


### PR DESCRIPTION
## Summary
This PR resolves issue #24 with a docs-only integration path for encrypted S3 backup/restore.

## Changes
- Added `COMMUNITY_SKILLS.md` with a documented community-skill catalog entry.
- Added a vetted entry for `openclaw-aws-backup-skill` (S3 + optional KMS backup/restore).
- Included install and common command quickstart snippets.
- Added security and operations notes (least-privilege IAM, KMS preference, retention, restore testing).
- Linked `COMMUNITY_SKILLS.md` from both `README.md` and `README_AGENTCORE.md`.

## Why
Issue #24 asks for backup capability integration. This approach keeps this repo focused while giving users a practical, discoverable path to use the existing community backup skill.

Closes #24