### PR TITLE
Revert typed VPC params to String for CLI compatibility

### DIFF
--- a/clawdbot-china.yaml
+++ b/clawdbot-china.yaml
@@ -6,6 +6,7 @@ Metadata:
     config:
       ignore_checks:
         - E6101
+        - W1030
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -150,16 +151,19 @@ Parameters:
     Description: "Set to 'true' to use an existing VPC instead of creating a new one"
 
   ExistingVPCId:
-    Type: AWS::EC2::VPC::Id
-    Description: "Select an existing VPC (ignored when creating new VPC). Must have DNS hostnames and DNS resolution enabled."
+    Type: String
+    Default: ""
+    Description: "ID of existing VPC (required if UseExistingVPC=true). Must have DNS hostnames and DNS resolution enabled."
 
   ExistingPublicSubnetId:
-    Type: AWS::EC2::Subnet::Id
-    Description: "Select an existing public subnet for EC2 (ignored when creating new VPC). Must have auto-assign public IP enabled."
+    Type: String
+    Default: ""
+    Description: "ID of existing public subnet for EC2 (required if UseExistingVPC=true). Must have auto-assign public IP enabled."
 
   ExistingPrivateSubnetId:
-    Type: AWS::EC2::Subnet::Id
-    Description: "Select an existing private subnet for VPC endpoints (ignored when creating new VPC)"
+    Type: String
+    Default: ""
+    Description: "ID of existing private subnet for VPC endpoints (required if UseExistingVPC=true)"
 
   VpcCidr:
     Type: String


### PR DESCRIPTION
## Summary
- Reverts `ExistingVPCId` from `AWS::EC2::VPC::Id` back to `String` with `Default: ""`
- Reverts `ExistingPublicSubnetId` and `ExistingPrivateSubnetId` from `AWS::EC2::Subnet::Id` back to `String` with `Default: ""`
- Re-adds W1030 cfn-lint suppression
- Keeps `Rules` section to validate VPC params are provided when `UseExistingVPC=true`

## Why
`AWS::EC2::VPC::Id` / `AWS::EC2::Subnet::Id` typed parameters require a valid resource ID at deploy time — even when `UseExistingVPC=false`. This forces CLI users to pass dummy VPC/subnet IDs when they just want to create a new VPC, breaking the default deployment path.

## Test plan
- [ ] Deploy with `UseExistingVPC=false` (default) via CLI without any VPC params — should succeed
- [ ] Deploy with `UseExistingVPC=true` without VPC params — should fail with Rules validation error
- [ ] Deploy with `UseExistingVPC=true` with valid VPC/subnet IDs — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)