### PR TITLE
feat: Update Bedrock auth for OpenClaw 2026.4.5

### DIFF
--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -12,6 +12,7 @@ Metadata:
           default: "Basic Configuration"
         Parameters:
           - OpenClawModel
+          - OpenClawVersion
           - InstanceType
           - KeyPairName
       - Label:
@@ -77,6 +78,11 @@ Parameters:
     Type: String
     Default: "true"
     Description: "Install Docker for sandboxed execution (recommended for group chats)"
+
+  OpenClawVersion:
+    Type: String
+    Default: "2026.4.5"
+    Description: "OpenClaw version to install (npm package version)"
 
   EnableDataProtection:
     Type: String
@@ -344,6 +350,15 @@ Resources:
                   - 'bedrock:InvokeModelWithResponseStream'
                   - 'bedrock:ListFoundationModels'
                   - 'bedrock:GetFoundationModel'
+                  - 'bedrock:ListInferenceProfiles'
+                Resource: '*'
+        - PolicyName: BedrockMantleAccessPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'bedrock-mantle:*'
                 Resource: '*'
         - PolicyName: SSMParameterPolicy
           PolicyDocument:
@@ -459,21 +474,14 @@ Resources:
                       "token": "GATEWAY_TOKEN_PLACEHOLDER"
                     }
                   },
-                  "models": {
-                    "providers": {
+                  "plugins": {
+                    "entries": {
                       "amazon-bedrock": {
-                        "baseUrl": "https://bedrock-runtime.REGION_PLACEHOLDER.amazonaws.com",
-                        "api": "bedrock-converse-stream",
-                        "auth": "aws-sdk",
-                        "models": [
-                          {
-                            "id": "MODEL_ID_PLACEHOLDER",
-                            "name": "Bedrock Model",
-                            "input": ["text", "image"],
-                            "contextWindow": 200000,
-                            "maxTokens": 8192
+                        "config": {
+                          "discovery": {
+                            "enabled": true
                           }
-                        ]
+                        }
                       }
                     }
                   },
@@ -481,6 +489,10 @@ Resources:
                     "defaults": {
                       "model": {
                         "primary": "amazon-bedrock/MODEL_ID_PLACEHOLDER"
+                      },
+                      "memorySearch": {
+                        "provider": "bedrock",
+                        "model": "amazon.titan-embed-text-v2:0"
                       }
                     }
                   }
@@ -669,17 +681,18 @@ Resources:
                   nvm alias default 22
 
                   npm config set registry https://registry.npmjs.org/
+                  OPENCLAW_VERSION="${OpenClawVersion}"
                   ARCH=$(uname -m)
                   if [ "$ARCH" = "aarch64" ]; then
                     echo "ARM64 detected, installing with --ignore-scripts..."
-                    npm install -g openclaw@2026.3.24 --timeout=300000 --ignore-scripts || {
+                    npm install -g openclaw@$OPENCLAW_VERSION --timeout=300000 --ignore-scripts || {
                       npm cache clean --force
-                      npm install -g openclaw@2026.3.24 --timeout=300000 --ignore-scripts
+                      npm install -g openclaw@$OPENCLAW_VERSION --timeout=300000 --ignore-scripts
                     }
                   else
-                    npm install -g openclaw@2026.3.24 --timeout=300000 || {
+                    npm install -g openclaw@$OPENCLAW_VERSION --timeout=300000 || {
                       npm cache clean --force
-                      npm install -g openclaw@2026.3.24 --timeout=300000
+                      npm install -g openclaw@$OPENCLAW_VERSION --timeout=300000
                     }
                   fi
 
@@ -739,7 +752,6 @@ Resources:
                   cp /opt/openclaw/openclaw-config.json /home/ubuntu/.openclaw/openclaw.json
                   chown ubuntu:ubuntu /home/ubuntu/.openclaw/openclaw.json
                   sed -i "s/GATEWAY_TOKEN_PLACEHOLDER/$GATEWAY_TOKEN/g" /home/ubuntu/.openclaw/openclaw.json
-                  sed -i "s/REGION_PLACEHOLDER/$AWS_REGION/g" /home/ubuntu/.openclaw/openclaw.json
                   sed -i "s|MODEL_ID_PLACEHOLDER|${OpenClawModel}|g" /home/ubuntu/.openclaw/openclaw.json
 
                   # Install and start gateway


### PR DESCRIPTION
## Summary

Updates CloudFormation Bedrock authentication to leverage OpenClaw 2026.4.5 improvements.

## Changes

### Config: Discovery mode replaces explicit provider config
- Replaces hardcoded `models.providers.amazon-bedrock` block (baseUrl, api, auth, models array) with `plugins.entries.amazon-bedrock.config.discovery.enabled: true`
- OpenClaw 2026.4.5 auto-discovers all enabled Bedrock models via `ListFoundationModels` + `ListInferenceProfiles`
- Removes `REGION_PLACEHOLDER` sed substitution — discovery injects region from AWS SDK credential chain automatically

### IAM: New permissions for discovery + Mantle
- Adds `bedrock:ListInferenceProfiles` — required for inference profile discovery (CFn uses profile IDs like `global.anthropic.claude-opus-4-6-v1`)
- Adds `bedrock-mantle:*` policy — required for Mantle OSS models (Kimi K2.5, GPT-OSS, Qwen, GLM) and IAM-based bearer token generation. Matches AWS managed policy [`AmazonBedrockMantleFullAccess`](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonBedrockMantleFullAccess.html)

### Version: Parameterized + bumped
- New `OpenClawVersion` CloudFormation parameter (default: `2026.4.5`, was hardcoded `2026.3.24`)
- Users can override version at deploy time

### Relevant OpenClaw 2026.4.5 changelog
- **Providers/Amazon Bedrock**: bundled Mantle support + inference-profile discovery + automatic request-region injection (#61296, #61299)
- **Providers/Amazon Bedrock Mantle**: generate bearer tokens from AWS credential chain — no manual `AWS_BEARER_TOKEN_BEDROCK` needed
- **Memory/search**: Amazon Bedrock embeddings support (Titan, Cohere, Nova, TwelveLabs)

## References
- [OpenClaw Bedrock docs](https://docs.openclaw.ai/providers/bedrock)
- [OpenClaw Bedrock Mantle docs](https://docs.openclaw.ai/providers/bedrock-mantle)
- [AmazonBedrockMantleFullAccess managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonBedrockMantleFullAccess.html)