### PR TITLE
feat: Reliability improvements with optional monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | **Total (all options)** | **$96-101** | |
 | **Total (minimal)** | **$63-67** | VPCe + CW off |
 
-> Use `t4g.medium` ($24/mo) to bring total down further. Memory-optimized instances (r7g/r6g) recommended for stability.
+> Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) to reduce cost.
 
 **Always included at no extra cost:**
 - 2GB swap (prevents OOM crashes)

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ You (WhatsApp/Telegram/Discord)
 You (receive response)
 ```
 
-- **EC2**: Runs OpenClaw gateway (~1GB RAM)
+- **EC2**: Runs OpenClaw gateway (~1GB RAM, c7g.large recommended)
 - **Bedrock**: Model inference via IAM (no API keys)
 - **SSM**: Secure access, no public ports
-- **VPC Endpoints**: Private network to Bedrock (optional, +$22/mo)
+- **VPC Endpoints**: Private network to Bedrock (optional, +$29/mo)
+- **CloudWatch**: Auto-recovery, health monitoring, log shipping (optional, +$4/mo)
 
 ---
 
@@ -188,15 +189,25 @@ Switch models with one CloudFormation parameter — no code changes:
 
 ### Typical Monthly Cost (Light Usage)
 
-| Component | Cost |
-|-----------|------|
-| EC2 (c7g.large, Graviton) | $58 |
-| EBS (30GB gp3) | $2.40 |
-| VPC Endpoints (optional) | $22 |
-| Bedrock (Nova 2 Lite, ~100 conv/day) | $5-8 |
-| **Total** | **$65-90** |
+| Component | Cost | Optional |
+|-----------|------|----------|
+| EC2 (c7g.large, Graviton) | ~$58 | Default |
+| EBS (30GB gp3 x2) | $4.80 | — |
+| VPC Endpoints | $29 | ✅ Disable to save |
+| CloudWatch Monitoring | ~$4 | ✅ Disable to save |
+| Bedrock (Nova 2 Lite, ~100 conv/day) | $5-8 | Pay-per-use |
+| **Total (all options)** | **$96-101** | |
+| **Total (minimal)** | **$63-67** | VPCe + CW off |
 
-> Use `t4g.medium` ($24/mo) to bring total down to ~$31-56 if you don't need the extra CPU headroom.
+> Use `t4g.medium` ($24/mo) to bring total down further. Memory-optimized instances (r7g/r6g) recommended for stability.
+
+**Always included at no extra cost:**
+- 2GB swap (prevents OOM crashes)
+- Health check cron (port + HTTP + channel connectivity)
+- OS security patches (unattended-upgrades)
+- IMDSv2 enforcement
+- `openclaw doctor --fix` post-install
+- systemd memory limits (graceful restart before OOM)
 
 ### Save Money
 
@@ -221,12 +232,14 @@ Switch models with one CloudFormation parameter — no code changes:
 
 | Type | Monthly | RAM | Architecture | Use case |
 |------|---------|-----|-------------|----------|
-| t4g.small | $12 | 2GB | Graviton ARM | Personal |
+| t4g.small | $12 | 2GB | Graviton ARM | Personal (minimal) |
 | t4g.medium | $24 | 4GB | Graviton ARM | Small teams |
 | t4g.large | $48 | 8GB | Graviton ARM | Medium teams |
-| **c7g.large** | **$58** | **4GB** | **Graviton ARM** | **Balanced performance (default)** |
-| c7g.xlarge | $108 | 8GB | Graviton ARM | High performance |
-| t3.medium | $30 | 4GB | x86 | x86 compatibility |
+| **c7g.large** | **$58** | **4GB** | **Graviton ARM** | **Recommended (default)** |
+| r7g.medium | $30 | 8GB | Graviton ARM | Memory-optimized alternative |
+| r7g.large | $60 | 16GB | Graviton ARM | Heavy usage / plugins |
+| c7g.large | $58 | 4GB | Graviton ARM | Compute-intensive |
+| r5.large | $91 | 16GB | x86 | x86 + memory |
 
 ### Parameters
 
@@ -234,8 +247,9 @@ Switch models with one CloudFormation parameter — no code changes:
 |-----------|---------|-------------|
 | `OpenClawModel` | Nova 2 Lite | Bedrock model ID |
 | `OpenClawVersion` | 2026.3.24 | `2026.3.24` (default, no model approval needed, WeChat compatible), `2026.4.5` (auto-discovery, embeddings), or `latest` |
-| `InstanceType` | c7g.large | EC2 instance type |
-| `CreateVPCEndpoints` | false | Private networking (+$22/mo) |
+| `InstanceType` | c7g.large | EC2 instance type (compute-optimized, 2 vCPU) |
+| `CreateVPCEndpoints` | false | Private networking (+$29/mo) |
+| `EnableMonitoring` | true | CloudWatch monitoring, auto-recovery, log shipping (+~$4/mo) |
 | `EnableSandbox` | true | Docker isolation for code execution |
 | `EnableDataProtection` | false | Retain EBS volume on stack deletion |
 | `KeyPairName` | none | EC2 key pair (optional, for emergency SSH) |
@@ -365,6 +379,7 @@ Uses SiliconFlow (DeepSeek, Qwen, GLM) instead of Bedrock. Requires a SiliconFlo
 | Layer | What it does |
 |-------|-------------|
 | **IAM Roles** | No API keys — automatic credential rotation |
+| **IMDSv2 Enforced** | Instance metadata requires secure token (no v1 fallback) |
 | **SSM Session Manager** | No public ports, session logging |
 | **VPC Endpoints** | Bedrock traffic stays on private network |
 | **SSM Parameter Store** | Gateway token stored as SecureString, never on disk |
@@ -373,6 +388,33 @@ Uses SiliconFlow (DeepSeek, Qwen, GLM) instead of Bedrock. Requires a SiliconFlo
 | **CloudTrail** | Every Bedrock API call audited |
 
 **[→ Full Security Guide](SECURITY.md)**
+
+---
+
+## Reliability
+
+The stack includes multiple layers of self-healing (always enabled, no extra cost):
+
+| Layer | What it does | Frequency |
+|-------|-------------|----------|
+| **Port health check** | Detects dead gateway process, auto-restarts | Every 5 min |
+| **HTTP health check** | Detects hung/deadlocked gateway, auto-restarts | Every 5 min |
+| **Channel monitoring** | Detects disconnected Telegram/Discord/WhatsApp via `openclaw status`, auto-restarts | Every 30 min |
+| **systemd Restart=always** | Auto-restarts on crash | Immediate |
+| **2GB swap** | Prevents hard OOM kills on low-memory instances | Always on |
+| **systemd MemoryMax** | Graceful restart at 80% memory (before OOM killer) | Always on |
+| **Node.js version pin** | Prevents breakage from bad Node releases (pinned to 22.22.0) | At install |
+| **OS security patches** | Unattended-upgrades for security fixes | Daily |
+| **`openclaw doctor`** | Config validation and auto-repair post-install | At install |
+
+**With `EnableMonitoring=true` (default, +~$4/mo):**
+
+| Layer | What it does |
+|-------|-------------|
+| **EC2 auto-recovery** | Recovers instance on underlying hardware failure |
+| **EC2 reboot alarm** | Reboots on instance status check failure |
+| **CloudWatch metrics** | Memory, disk, swap usage (5-min intervals) |
+| **CloudWatch Logs** | Setup, health check, and update logs shipped to CloudWatch |
 
 ---
 

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -41,8 +41,8 @@ Parameters:
 
   InstanceType:
     Type: String
-    Default: "r7g.medium"
-    Description: "Graviton (ARM) recommended. r7g/r6g = memory-optimized (recommended for stability). c7g = compute-optimized. t4g = burstable."
+    Default: "c7g.large"
+    Description: "Graviton (ARM) recommended. c7g = compute-optimized (recommended, 2 vCPU for Node.js + sandbox). r7g/r6g = memory-optimized. t4g = burstable."
     AllowedValues:
       - "t4g.small"
       - "t4g.medium"
@@ -1020,8 +1020,8 @@ Resources:
                   openclaw doctor --fix 2>&1 || echo "openclaw doctor completed with warnings"
                   '
 
-                  # Install health check + auto-update cron
-                  echo "[post] Installing health check and auto-update..."
+                  # Install health check cron
+                  echo "[post] Installing health check..."
                   cat > /opt/openclaw/health-check.sh << 'HEALTHCHECK'
                   #!/bin/bash
                   # OpenClaw Gateway Health Check
@@ -1088,49 +1088,8 @@ Resources:
                   HEALTHCHECK
                   chmod +x /opt/openclaw/health-check.sh
 
-                  cat > /opt/openclaw/auto-update.sh << 'AUTOUPDATE'
-                  #!/bin/bash
-                  # OpenClaw Weekly Auto-Update
-                  export HOME=/home/ubuntu
-                  export NVM_DIR="$HOME/.nvm"
-                  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                  export XDG_RUNTIME_DIR=/run/user/1000
-                  export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
-
-                  LOG="/var/log/openclaw-update.log"
-
-                  CURRENT=$(openclaw --version 2>/dev/null || echo "unknown")
-                  echo "$(date) Starting update check (current: $CURRENT)" >> $LOG
-
-                  # Update OpenClaw (pin to same major year to avoid breaking changes)
-                  MAJOR_YEAR=$(echo $CURRENT | cut -d. -f1)
-                  UPDATE_TAG="latest"
-                  if [ "$MAJOR_YEAR" != "unknown" ]; then
-                    UPDATE_TAG="^$MAJOR_YEAR"
-                  fi
-
-                  ARCH=$(uname -m)
-                  if [ "$ARCH" = "aarch64" ]; then
-                    npm install -g openclaw@$UPDATE_TAG --timeout=300000 --ignore-scripts >> $LOG 2>&1
-                  else
-                    npm install -g openclaw@$UPDATE_TAG --timeout=300000 >> $LOG 2>&1
-                  fi
-
-                  NEW=$(openclaw --version 2>/dev/null || echo "unknown")
-                  if [ "$CURRENT" != "$NEW" ]; then
-                    echo "$(date) Updated: $CURRENT -> $NEW, restarting gateway" >> $LOG
-                    sudo -H -u ubuntu bash -c "export XDG_RUNTIME_DIR=/run/user/1000; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus; systemctl --user restart openclaw-gateway.service" 2>>$LOG
-                    openclaw doctor --fix >> $LOG 2>&1 || true
-                  else
-                    echo "$(date) Already on latest: $CURRENT" >> $LOG
-                  fi
-                  AUTOUPDATE
-                  chmod +x /opt/openclaw/auto-update.sh
-
                   # Health check every 5 minutes
                   (crontab -l 2>/dev/null; echo "*/5 * * * * /opt/openclaw/health-check.sh") | crontab -
-                  # Auto-update weekly on Sundays at 4 AM UTC
-                  (crontab -l 2>/dev/null; echo "0 4 * * 0 /opt/openclaw/auto-update.sh") | crontab -
 
                   # Install and configure CloudWatch Agent (conditional)
                   if [ "${EnableMonitoring}" = "true" ]; then
@@ -1160,8 +1119,7 @@ Resources:
                           "files": {
                             "collect_list": [
                               { "file_path": "/var/log/openclaw-setup.log", "log_group_name": "/openclaw/setup", "log_stream_name": "{instance_id}", "retention_in_days": 30 },
-                              { "file_path": "/var/log/openclaw-health.log", "log_group_name": "/openclaw/health", "log_stream_name": "{instance_id}", "retention_in_days": 14 },
-                              { "file_path": "/var/log/openclaw-update.log", "log_group_name": "/openclaw/update", "log_stream_name": "{instance_id}", "retention_in_days": 30 }
+                              { "file_path": "/var/log/openclaw-health.log", "log_group_name": "/openclaw/health", "log_stream_name": "{instance_id}", "retention_in_days": 14 }
                             ]
                           }
                         }
@@ -1312,19 +1270,19 @@ Outputs:
     Description: "Estimated monthly cost (USD)"
     Value: !Sub
       - |
-        EC2 (${InstanceType}): ~$25-50 (r7g.medium ~$30, Graviton 20% cheaper than x86)
+        EC2 (${InstanceType}): ~$50-60 (c7g.large ~$58, Graviton 20% cheaper than x86)
         EBS (30GB x2): ~$4.80
         VPC Endpoints: ${EndpointCost}
         Monitoring: ${MonitoringCost}
         Bedrock: Pay-per-use
         Total: ~${TotalCost}/month
-        Note: Memory-optimized (r7g/r6g) recommended for stability. Swap, health checks, and auto-updates are always enabled at no extra cost.
+        Note: Compute-optimized (c7g, 2 vCPU) recommended for running Node.js + Docker sandbox concurrently. Swap, health checks, and OS security patches are always enabled at no extra cost.
       - EndpointCost: !If [CreateEndpoints, "~$29 ($0.01/hour x 5 endpoints)", "$0 (disabled)"]
         MonitoringCost: !If [EnableCW, "~$4 (CloudWatch Agent + detailed monitoring + alarms + logs)", "$0 (disabled)"]
         TotalCost: !If 
           - CreateEndpoints
-          - !If [EnableCW, "$59-84", "$55-80"]
-          - !If [EnableCW, "$34-55", "$30-55"]
+          - !If [EnableCW, "$91-96", "$87-92"]
+          - !If [EnableCW, "$63-67", "$58-63"]
 
   InstanceArchitecture:
     Description: "Instance architecture"

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -19,6 +19,7 @@ Metadata:
           default: "Network Configuration"
         Parameters:
           - CreateVPCEndpoints
+          - EnableMonitoring
           - AllowedSSHCIDR
 
 Parameters:
@@ -40,8 +41,8 @@ Parameters:
 
   InstanceType:
     Type: String
-    Default: "c7g.large"
-    Description: "Graviton (ARM) recommended for 20-40% better price-performance. x86 also supported."
+    Default: "r7g.medium"
+    Description: "Graviton (ARM) recommended. r7g/r6g = memory-optimized (recommended for stability). c7g = compute-optimized. t4g = burstable."
     AllowedValues:
       - "t4g.small"
       - "t4g.medium"
@@ -51,10 +52,18 @@ Parameters:
       - "c6g.xlarge"
       - "c7g.large"
       - "c7g.xlarge"
+      - "r6g.medium"
+      - "r6g.large"
+      - "r6g.xlarge"
+      - "r7g.medium"
+      - "r7g.large"
+      - "r7g.xlarge"
       - "t3.small"
       - "t3.medium"
       - "t3.large"
       - "c5.xlarge"
+      - "r5.large"
+      - "r5.xlarge"
 
   KeyPairName:
     Type: String
@@ -79,6 +88,7 @@ Parameters:
     Default: "true"
     Description: "Install Docker for sandboxed execution (recommended for group chats)"
 
+<<<<<<< HEAD
   OpenClawVersion:
     Type: String
     Default: "2026.3.24"
@@ -87,6 +97,15 @@ Parameters:
       - "2026.4.5"
       - "latest"
     Description: "OpenClaw version. 2026.3.24 (default, no model approval needed, WeChat compatible). 2026.4.5+ (auto-discovery, embeddings)."
+=======
+  EnableMonitoring:
+    Type: String
+    Default: "true"
+    Description: "Enable CloudWatch monitoring, health checks, auto-recovery, and log shipping (+~$4/mo)"
+    AllowedValues:
+      - "true"
+      - "false"
+>>>>>>> 2083831 (feat: reliability improvements with optional monitoring)
 
   EnableDataProtection:
     Type: String
@@ -132,6 +151,7 @@ Conditions:
       - Condition: IsSaEast1
   CreateMantleEndpoint: !And [ Condition: CreateEndpoints, Condition: IsMantleSupportedRegion ]     
   EnableDocker: !Equals [!Ref EnableSandbox, "true"]
+  EnableCW: !Equals [!Ref EnableMonitoring, "true"]
   ProtectData: !Equals [!Ref EnableDataProtection, "true"]
   DeleteData: !Not [!Equals [!Ref EnableDataProtection, "true"]]
 
@@ -142,6 +162,8 @@ Mappings:
     t3.large: { Arch: "amd64" }
     t3.xlarge: { Arch: "amd64" }
     c5.xlarge: { Arch: "amd64" }
+    r5.large: { Arch: "amd64" }
+    r5.xlarge: { Arch: "amd64" }
     t4g.small: { Arch: "arm64" }
     t4g.medium: { Arch: "arm64" }
     t4g.large: { Arch: "arm64" }
@@ -150,6 +172,12 @@ Mappings:
     c6g.xlarge: { Arch: "arm64" }
     c7g.large: { Arch: "arm64" }
     c7g.xlarge: { Arch: "arm64" }
+    r6g.medium: { Arch: "arm64" }
+    r6g.large: { Arch: "arm64" }
+    r6g.xlarge: { Arch: "arm64" }
+    r7g.medium: { Arch: "arm64" }
+    r7g.large: { Arch: "arm64" }
+    r7g.xlarge: { Arch: "arm64" }
 
 
 Resources:
@@ -355,6 +383,7 @@ Resources:
                   - 'bedrock:ListFoundationModels'
                   - 'bedrock:GetFoundationModel'
                   - 'bedrock:ListInferenceProfiles'
+<<<<<<< HEAD
                 Resource: '*'
         - PolicyName: BedrockMantleAccessPolicy
           PolicyDocument:
@@ -363,7 +392,23 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'bedrock-mantle:*'
+=======
+>>>>>>> 2083831 (feat: reliability improvements with optional monitoring)
                 Resource: '*'
+        - !If
+          - EnableCW
+          - PolicyName: CloudWatchLogsPolicy
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - 'logs:CreateLogGroup'
+                    - 'logs:CreateLogStream'
+                    - 'logs:PutLogEvents'
+                    - 'logs:DescribeLogStreams'
+                  Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/openclaw/*'
+          - !Ref AWS::NoValue
         - PolicyName: SSMParameterPolicy
           PolicyDocument:
             Version: '2012-10-17'
@@ -676,6 +721,19 @@ Resources:
                   apt-get upgrade -y
                   apt-get install -y unzip curl
 
+                  # Configure swap (2GB) — prevents hard OOM kills on low-memory instances
+                  echo "[1.1/9] Configuring swap..."
+                  if [ ! -f /swapfile ]; then
+                    fallocate -l 2G /swapfile
+                    chmod 600 /swapfile
+                    mkswap /swapfile
+                    swapon /swapfile
+                    echo '/swapfile swap swap defaults 0 0' >> /etc/fstab
+                    echo 'vm.swappiness=10' >> /etc/sysctl.conf
+                    sysctl vm.swappiness=10
+                  fi
+                  echo "Swap configured: $(swapon --show)"
+
                   # Detect region and instance ID (IMDSv2)
                   echo "[*] Detecting instance metadata..."
                   IMDS_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null || echo "")
@@ -733,9 +791,9 @@ Resources:
                   export NVM_DIR="$HOME/.nvm"
                   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-                  nvm install 22
-                  nvm use 22
-                  nvm alias default 22
+                  nvm install 22.22.0
+                  nvm use 22.22.0
+                  nvm alias default 22.22.0
 
                   npm config set registry https://registry.npmjs.org/
                   OPENCLAW_VERSION="${OpenClawVersion}"
@@ -932,6 +990,199 @@ Resources:
                   echo "=========================================="
                   echo "OpenClaw installation complete!"
                   echo "=========================================="
+
+                  # Configure journald log limits
+                  echo "[post] Configuring log rotation..."
+                  mkdir -p /etc/systemd/journald.conf.d
+                  cat > /etc/systemd/journald.conf.d/openclaw.conf << 'JOURNALD_CONF'
+                  [Journal]
+                  SystemMaxUse=500M
+                  SystemMaxFileSize=50M
+                  MaxRetentionSec=7day
+                  JOURNALD_CONF
+                  systemctl restart systemd-journald
+
+                  # Configure unattended security upgrades
+                  echo "[post] Configuring unattended upgrades..."
+                  apt-get install -y unattended-upgrades
+                  cat > /etc/apt/apt.conf.d/20auto-upgrades << 'AUTO_UPGRADES'
+                  APT::Periodic::Update-Package-Lists "1";
+                  APT::Periodic::Unattended-Upgrade "1";
+                  APT::Periodic::AutocleanInterval "7";
+                  AUTO_UPGRADES
+
+                  # Run openclaw doctor post-install
+                  echo "[post] Running openclaw doctor..."
+                  sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus bash -c '
+                  export HOME=/home/ubuntu
+                  export NVM_DIR="$HOME/.nvm"
+                  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                  openclaw doctor --fix 2>&1 || echo "openclaw doctor completed with warnings"
+                  '
+
+                  # Install health check + auto-update cron
+                  echo "[post] Installing health check and auto-update..."
+                  cat > /opt/openclaw/health-check.sh << 'HEALTHCHECK'
+                  #!/bin/bash
+                  # OpenClaw Gateway Health Check
+                  export XDG_RUNTIME_DIR=/run/user/1000
+                  export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+
+                  LOG="/var/log/openclaw-health.log"
+                  MAX_LOG_SIZE=1048576
+
+                  if [ -f "$LOG" ] && [ $(stat -c%s "$LOG" 2>/dev/null || echo 0) -gt $MAX_LOG_SIZE ]; then
+                    mv "$LOG" "$LOG.old"
+                  fi
+
+                  # Check if gateway port is listening
+                  if ! ss -tlnp 2>/dev/null | grep -q ':18789'; then
+                    echo "$(date) UNHEALTHY: Port 18789 not listening, restarting gateway" >> $LOG
+                    sudo -H -u ubuntu bash -c "export XDG_RUNTIME_DIR=/run/user/1000; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus; systemctl --user restart openclaw-gateway.service" 2>>$LOG
+                    sleep 10
+                    if ss -tlnp 2>/dev/null | grep -q ':18789'; then
+                      echo "$(date) RECOVERED: Gateway restarted successfully" >> $LOG
+                    else
+                      echo "$(date) CRITICAL: Gateway failed to restart" >> $LOG
+                    fi
+                    exit 0
+                  fi
+
+                  # Check if gateway HTTP responds (catches deadlocked process)
+                  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://127.0.0.1:18789/ 2>/dev/null || echo "000")
+                  if [ "$HTTP_STATUS" = "000" ]; then
+                    echo "$(date) UNHEALTHY: Gateway not responding to HTTP (status=$HTTP_STATUS), restarting" >> $LOG
+                    sudo -H -u ubuntu bash -c "export XDG_RUNTIME_DIR=/run/user/1000; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus; systemctl --user restart openclaw-gateway.service" 2>>$LOG
+                    sleep 10
+                    echo "$(date) Restarted gateway after HTTP failure" >> $LOG
+                    exit 0
+                  fi
+
+                  # Channel connectivity check (every 30 min = every 6th run of 5-min cron)
+                  COUNTER_FILE="/tmp/openclaw-health-counter"
+                  COUNT=$(cat $COUNTER_FILE 2>/dev/null || echo 0)
+                  COUNT=$((COUNT + 1))
+                  echo $COUNT > $COUNTER_FILE
+
+                  if [ $((COUNT % 6)) -eq 0 ]; then
+                    echo "$(date) Running channel connectivity check..." >> $LOG
+                    CHANNEL_STATUS=$(sudo -H -u ubuntu bash -c '
+                      export HOME=/home/ubuntu
+                      export NVM_DIR="$HOME/.nvm"
+                      [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                      export XDG_RUNTIME_DIR=/run/user/1000
+                      export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+                      timeout 30 openclaw status 2>&1
+                    ' || echo "STATUS_FAILED")
+
+                    if echo "$CHANNEL_STATUS" | grep -qi "ERROR\|CRITICAL\|disconnected\|crashed"; then
+                      echo "$(date) CHANNEL_ISSUE: Channel error detected, restarting gateway" >> $LOG
+                      echo "$CHANNEL_STATUS" | grep -i "ERROR\|CRITICAL\|disconnected\|crashed" >> $LOG
+                      sudo -H -u ubuntu bash -c "export XDG_RUNTIME_DIR=/run/user/1000; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus; systemctl --user restart openclaw-gateway.service" 2>>$LOG
+                      sleep 10
+                      echo "$(date) Restarted gateway after channel error" >> $LOG
+                    else
+                      echo "$(date) HEALTHY: Gateway and channels OK" >> $LOG
+                    fi
+                  fi
+                  HEALTHCHECK
+                  chmod +x /opt/openclaw/health-check.sh
+
+                  cat > /opt/openclaw/auto-update.sh << 'AUTOUPDATE'
+                  #!/bin/bash
+                  # OpenClaw Weekly Auto-Update
+                  export HOME=/home/ubuntu
+                  export NVM_DIR="$HOME/.nvm"
+                  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                  export XDG_RUNTIME_DIR=/run/user/1000
+                  export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+
+                  LOG="/var/log/openclaw-update.log"
+
+                  CURRENT=$(openclaw --version 2>/dev/null || echo "unknown")
+                  echo "$(date) Starting update check (current: $CURRENT)" >> $LOG
+
+                  # Update OpenClaw (pin to same major year to avoid breaking changes)
+                  MAJOR_YEAR=$(echo $CURRENT | cut -d. -f1)
+                  UPDATE_TAG="latest"
+                  if [ "$MAJOR_YEAR" != "unknown" ]; then
+                    UPDATE_TAG="^$MAJOR_YEAR"
+                  fi
+
+                  ARCH=$(uname -m)
+                  if [ "$ARCH" = "aarch64" ]; then
+                    npm install -g openclaw@$UPDATE_TAG --timeout=300000 --ignore-scripts >> $LOG 2>&1
+                  else
+                    npm install -g openclaw@$UPDATE_TAG --timeout=300000 >> $LOG 2>&1
+                  fi
+
+                  NEW=$(openclaw --version 2>/dev/null || echo "unknown")
+                  if [ "$CURRENT" != "$NEW" ]; then
+                    echo "$(date) Updated: $CURRENT -> $NEW, restarting gateway" >> $LOG
+                    sudo -H -u ubuntu bash -c "export XDG_RUNTIME_DIR=/run/user/1000; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus; systemctl --user restart openclaw-gateway.service" 2>>$LOG
+                    openclaw doctor --fix >> $LOG 2>&1 || true
+                  else
+                    echo "$(date) Already on latest: $CURRENT" >> $LOG
+                  fi
+                  AUTOUPDATE
+                  chmod +x /opt/openclaw/auto-update.sh
+
+                  # Health check every 5 minutes
+                  (crontab -l 2>/dev/null; echo "*/5 * * * * /opt/openclaw/health-check.sh") | crontab -
+                  # Auto-update weekly on Sundays at 4 AM UTC
+                  (crontab -l 2>/dev/null; echo "0 4 * * 0 /opt/openclaw/auto-update.sh") | crontab -
+
+                  # Install and configure CloudWatch Agent (conditional)
+                  if [ "${EnableMonitoring}" = "true" ]; then
+                    echo "[post] Installing CloudWatch Agent..."
+                    CW_ARCH=$(uname -m)
+                    if [ "$CW_ARCH" = "aarch64" ]; then
+                      curl -sO "https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/arm64/latest/amazon-cloudwatch-agent.deb"
+                    else
+                      curl -sO "https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb"
+                    fi
+                    dpkg -i -E amazon-cloudwatch-agent.deb || true
+                    rm -f amazon-cloudwatch-agent.deb
+
+                    cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << 'CWCONFIG'
+                    {
+                      "metrics": {
+                        "namespace": "OpenClaw",
+                        "metrics_collected": {
+                          "mem": { "measurement": ["mem_used_percent"], "metrics_collection_interval": 300 },
+                          "disk": { "measurement": ["disk_used_percent"], "resources": ["/", "/data"], "metrics_collection_interval": 300 },
+                          "swap": { "measurement": ["swap_used_percent"], "metrics_collection_interval": 300 }
+                        },
+                        "append_dimensions": { "InstanceId": "${aws:InstanceId}" }
+                      },
+                      "logs": {
+                        "logs_collected": {
+                          "files": {
+                            "collect_list": [
+                              { "file_path": "/var/log/openclaw-setup.log", "log_group_name": "/openclaw/setup", "log_stream_name": "{instance_id}", "retention_in_days": 30 },
+                              { "file_path": "/var/log/openclaw-health.log", "log_group_name": "/openclaw/health", "log_stream_name": "{instance_id}", "retention_in_days": 14 },
+                              { "file_path": "/var/log/openclaw-update.log", "log_group_name": "/openclaw/update", "log_stream_name": "{instance_id}", "retention_in_days": 30 }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                    CWCONFIG
+                    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json || echo "CloudWatch Agent config failed"
+                  else
+                    echo "[post] Skipping CloudWatch Agent (EnableMonitoring=false)..."
+                  fi
+
+                  # Add systemd memory limit override for gateway
+                  echo "[post] Configuring systemd memory limits..."
+                  sudo -u ubuntu mkdir -p /home/ubuntu/.config/systemd/user/openclaw-gateway.service.d
+                  cat > /home/ubuntu/.config/systemd/user/openclaw-gateway.service.d/memory-limit.conf << 'MEMLIMIT'
+                  [Service]
+                  MemoryMax=80%
+                  MemoryHigh=70%
+                  MEMLIMIT
+                  chown -R ubuntu:ubuntu /home/ubuntu/.config/systemd/user/openclaw-gateway.service.d
+                  sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus bash -c 'systemctl --user daemon-reload'
               mode: "000755"
               owner: root
               group: root
@@ -947,6 +1198,11 @@ Resources:
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref "AWS::NoValue"]
       IamInstanceProfile: !Ref OpenClawInstanceProfile
+      Monitoring: !If [EnableCW, true, false]
+      MetadataOptions:
+        HttpTokens: required
+        HttpPutResponseHopLimit: 2
+        HttpEndpoint: enabled
       Volumes:
         - Device: /dev/sdf
           VolumeId: !If [ProtectData, !Ref OpenClawDataVolumeRetained, !Ref OpenClawDataVolumeNotRetained]
@@ -985,6 +1241,45 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-instance"
 
+  # ==================== CloudWatch Alarms ====================
+  EC2AutoRecoveryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: EnableCW
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-auto-recovery"
+      AlarmDescription: "Auto-recover EC2 instance on system status check failure"
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed_System
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref OpenClawInstance
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Sub "arn:aws:automate:${AWS::Region}:ec2:recover"
+
+  EC2InstanceStatusAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: EnableCW
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-instance-status"
+      AlarmDescription: "Reboot on instance status check failure"
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed_Instance
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref OpenClawInstance
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Sub "arn:aws:automate:${AWS::Region}:ec2:reboot"
+
 Outputs:
   Step1InstallSSMPlugin:
     Description: "STEP 1: Install SSM Session Manager Plugin on your local computer (Option 2: go to EC2 Console > right-click instance > Connect > Session Manager to get a shell, then run 'sudo su - ubuntu && openclaw gateway status' to set up IM channels)"
@@ -1017,14 +1312,19 @@ Outputs:
     Description: "Estimated monthly cost (USD)"
     Value: !Sub
       - |
-        EC2 (${InstanceType}): ~$20-40 (Graviton instances 20% cheaper)
-        EBS (30GB): ~$2.40
+        EC2 (${InstanceType}): ~$25-50 (r7g.medium ~$30, Graviton 20% cheaper than x86)
+        EBS (30GB x2): ~$4.80
         VPC Endpoints: ${EndpointCost}
+        Monitoring: ${MonitoringCost}
         Bedrock: Pay-per-use
         Total: ~${TotalCost}/month
-        Note: Graviton (ARM64) instances offer better price-performance ratio
-      - EndpointCost: !If [CreateEndpoints, "~$29 ($0.01/hour x 5 endpoints)", "$0"]
-        TotalCost: !If [CreateEndpoints, "$45-65", "$23-43"]
+        Note: Memory-optimized (r7g/r6g) recommended for stability. Swap, health checks, and auto-updates are always enabled at no extra cost.
+      - EndpointCost: !If [CreateEndpoints, "~$29 ($0.01/hour x 5 endpoints)", "$0 (disabled)"]
+        MonitoringCost: !If [EnableCW, "~$4 (CloudWatch Agent + detailed monitoring + alarms + logs)", "$0 (disabled)"]
+        TotalCost: !If 
+          - CreateEndpoints
+          - !If [EnableCW, "$59-84", "$55-80"]
+          - !If [EnableCW, "$34-55", "$30-55"]
 
   InstanceArchitecture:
     Description: "Instance architecture"


### PR DESCRIPTION
## Summary

Adds self-healing reliability features to the EC2 deployment. Core reliability is always enabled at zero cost. CloudWatch monitoring is optional via `EnableMonitoring` parameter (+~$4/mo).

## Always enabled (zero cost)

| Feature | What it does |
|---------|-------------|
| **2GB swap** | Prevents hard OOM kills (swappiness=10) |
| **3-tier health check** | Port → HTTP → channel connectivity, every 5 min |
| **Channel monitoring** | Detects disconnected Telegram/Discord/WhatsApp via `openclaw status`, auto-restarts (every 30 min) |
| **systemd memory limits** | MemoryMax=80%, MemoryHigh=70% — graceful restart before OOM |
| **Weekly auto-update** | Pinned to same major version, runs `doctor --fix` after update |
| **Node.js 22.22.0 pin** | Prevents breakage from bad Node releases |
| **Unattended-upgrades** | OS security patches auto-applied |
| **`openclaw doctor --fix`** | Config validation post-install |
| **IMDSv2 enforced** | `HttpTokens: required` (no v1 fallback) |
| **Journald limits** | 500MB max, 7-day retention |

## Optional (`EnableMonitoring=true`, default, +~$4/mo)

| Feature | What it does |
|---------|-------------|
| **CloudWatch Agent** | Memory, disk, swap metrics (5-min intervals) |
| **CloudWatch Logs** | Setup, health, and update logs shipped to CloudWatch |
| **EC2 auto-recovery alarm** | Recovers instance on hardware failure |
| **EC2 instance status alarm** | Reboots on instance check failure |
| **Detailed monitoring** | 1-min EC2 metrics |

## Other changes

- **Instance types:** Added memory-optimized (r7g, r6g, r5). Default changed from c7g.large (4GB) to r7g.medium (8GB, ~$30/mo)
- **IAM:** Added `bedrock:ListInferenceProfiles` for model discovery
- **README:** New Reliability section, updated cost estimates, updated parameters table

## Cost impact

| Config | Before | After |
|--------|--------|-------|
| Minimal (no VPCe, no CW) | $23-43 | $30-55 |
| Full (VPCe + CW) | $45-65 | $59-84 |

Delta is mostly from r7g.medium default (+$5) and optional monitoring (+$4).