### PR TITLE
Fix reset script to restore .env for Bedrock IAM auth

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -562,6 +562,10 @@ cat > ~/.clawdbot/clawdbot.json << EOF
 }
 EOF
 
+# Restore .env for Bedrock IAM auth (required for OpenClaw 2026.4.5+)
+# See: https://docs.openclaw.ai/providers/bedrock (EC2 Instance Roles)
+printf 'AWS_PROFILE=default\nAWS_REGION=%s\nAWS_DEFAULT_REGION=%s\n' "$REGION" "$REGION" > ~/.openclaw/.env
+
 # Restart service
 XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart clawdbot-gateway
 


### PR DESCRIPTION
## Summary

The Reset Configuration script in TROUBLESHOOTING.md recreates `openclaw.json` but does not restore `~/.openclaw/.env`, which is required for OpenClaw 2026.4.5+ to discover IAM credentials from EC2 instance metadata (IMDS).

Without this file, users who reset their config hit:
```
No API key found for amazon-bedrock.
Use /login or set an API key environment variable.
```

This PR adds the `.env` restore step to match what the CloudFormation template already writes during initial deployment (`clawdbot-bedrock.yaml`, line 796).

## What changed in OpenClaw v2026.4.5+

OpenClaw v2026.4.5 switched its model engine to `pi-coding-agent`, which introduced breaking changes for Bedrock auth on EC2:

- **`"auth": "aws-sdk"` in `openclaw.json` is no longer read** — auth is now resolved purely via environment variables
- **`AWS_PROFILE` env var is required** — the new runtime checks for `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, or `AWS_BEARER_TOKEN_BEDROCK` before falling through to the SDK credential chain. On EC2 with IAM instance roles, none of these are set by default, so auth fails ([openclaw/openclaw#62995](https://github.com/openclaw/openclaw/issues/62995))
- **`"api": "bedrock-converse-stream"` is still required** — without it, v2026.4.5 defaults to raw HTTP calls instead of the AWS SDK converse stream API, causing "LLM request timed out" errors
- **`"baseUrl"` is still required** — removing it causes config validation failure
- **`~/.openclaw/.env` is the durable fix** — this file is loaded by the gateway systemd service via `EnvironmentFile=` and survives gateway reinstalls and upgrades

Setting `AWS_PROFILE=default` tells the AWS SDK to resolve credentials via the default credential chain, which includes IMDS (EC2 instance profile). This is documented in the [official OpenClaw Bedrock provider docs](https://docs.openclaw.ai/providers/bedrock) under "EC2 Instance Roles".

## References

- [OpenClaw Bedrock Provider Docs — EC2 Instance Roles](https://docs.openclaw.ai/providers/bedrock)
- [openclaw/openclaw#62995](https://github.com/openclaw/openclaw/issues/62995) — v2026.4.5 regression: "No API key found" with instance role
- [pi-mono providers.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) — upstream Bedrock auth docs