### PR TITLE
Update IM channel setup examples to match current CLI syntax

### DIFF
--- a/enterprise/admin-console/src/pages/IMChannels.tsx
+++ b/enterprise/admin-console/src/pages/IMChannels.tsx
@@ -274,7 +274,7 @@ function ChannelConnections({ channel, connections, channelStatus, onRevoke, ins
           <ol className="text-xs text-text-muted space-y-1 list-decimal list-inside">
             <li>SSM into EC2: <code className="bg-dark-hover px-1 rounded">aws ssm start-session --target {instanceId} --region {region}</code></li>
             <li>Switch user: <code className="bg-dark-hover px-1 rounded">sudo su - ubuntu</code></li>
-            <li>Add channel: <code className="bg-dark-hover px-1 rounded">openclaw channels add {channel} --token YOUR_BOT_TOKEN</code></li>
+            <li>Add channel: <code className="bg-dark-hover px-1 rounded">openclaw channels add --channel {channel} --token YOUR_BOT_TOKEN</code></li>
             <li>Verify: <code className="bg-dark-hover px-1 rounded">openclaw channels list</code></li>
             <li>Come back here and click <strong>Refresh</strong> to confirm status</li>
           </ol>
@@ -436,7 +436,7 @@ export default function IMChannels() {
               </div>
               <p className="text-xs text-text-muted">
                 Use the OpenClaw CLI to add a channel:
-                <code className="bg-dark-hover px-1 rounded block mt-1">openclaw channels add telegram --token YOUR_BOT_TOKEN</code>
+                <code className="bg-dark-hover px-1 rounded block mt-1">openclaw channels add --channel telegram --token YOUR_BOT_TOKEN</code>
                 Repeat for each platform. Run <code className="bg-dark-hover px-1 rounded">openclaw channels list</code> to verify.
               </p>
             </div>

--- a/enterprise/docs/ENTERPRISE-OPERATIONS-GUIDE.md
+++ b/enterprise/docs/ENTERPRISE-OPERATIONS-GUIDE.md
@@ -216,16 +216,16 @@ sudo su - ubuntu
 
 ```bash
 # Telegram — get token from @BotFather
-openclaw channels add telegram --token "YOUR_TELEGRAM_BOT_TOKEN"
+openclaw channels add --channel telegram --token "YOUR_TELEGRAM_BOT_TOKEN"
 
 # Discord — get token from discord.com/developers → Bot tab
-openclaw channels add discord --token "YOUR_DISCORD_BOT_TOKEN"
+openclaw channels add --channel discord --token "YOUR_DISCORD_BOT_TOKEN"
 
 # Slack — get token from api.slack.com/apps → Bot User OAuth Token
-openclaw channels add slack --bot-token "xoxb-YOUR_TOKEN" --app-token "xapp-YOUR_TOKEN"
+openclaw channels add --channel slack --bot-token "xoxb-YOUR_TOKEN" --app-token "xapp-YOUR_TOKEN"
 
 # Feishu / Lark — get App ID + Secret from Feishu Admin Console
-openclaw channels add feishu --app-id "YOUR_APP_ID" --app-secret "YOUR_APP_SECRET"
+openclaw channels add --channel feishu --app-id "YOUR_APP_ID" --app-secret "YOUR_APP_SECRET"
 
 # Verify all channels
 openclaw channels list


### PR DESCRIPTION
## Summary
- update the IM channel setup examples to use the current `openclaw channels add --channel ...` syntax
- align the admin UI guidance with the operations guide examples

## Why
The current setup instructions still show the older positional channel syntax. In a fresh enterprise deployment, following those commands can fail even though the channel integration itself is installed correctly.

## Validation
- updated the operations guide examples for Telegram, Discord, Slack, and Feishu
- updated the matching admin UI setup copy in `IMChannels.tsx`
