### PR TITLE
Allow enterprise hosts to stop AgentCore runtime sessions

### DIFF
--- a/enterprise/clawdbot-bedrock-agentcore-multitenancy.yaml
+++ b/enterprise/clawdbot-bedrock-agentcore-multitenancy.yaml
@@ -338,6 +338,7 @@ Resources:
                 Action:
                   - 'bedrock-agentcore:InvokeAgentRuntime'
                   - 'bedrock-agentcore:GetAgentRuntime'
+                  - 'bedrock-agentcore:StopRuntimeSession'
                 Resource: '*'
         - PolicyName: ECRAccessPolicy
           PolicyDocument:


### PR DESCRIPTION
## Summary
- allow the EC2 host role to call `bedrock-agentcore:StopRuntimeSession`

## Why
The enterprise deployment includes session stop / refresh flows, but the EC2 host role currently lacks permission to stop AgentCore runtime sessions. That leaves stale sessions running even when the platform tries to reset them.

## Validation
- reviewed the host role policy in `enterprise/clawdbot-bedrock-agentcore-multitenancy.yaml`
- confirmed this change only adds the missing AgentCore action alongside the existing invoke/get permissions
