### PR TITLE
Preserve runtime configuration during AgentCore updates

### DIFF
--- a/enterprise/deploy.sh
+++ b/enterprise/deploy.sh
@@ -307,6 +307,11 @@ if [ -n "$EXISTING_RUNTIME" ] && [ "$EXISTING_RUNTIME" != "UNKNOWN" ]; then
     --agent-runtime-artifact "{\"containerConfiguration\":{\"containerUri\":\"${ECR_URI}:latest\"}}" \
     --role-arn "$EXECUTION_ROLE_ARN" \
     --network-configuration '{"networkMode":"PUBLIC"}' \
+    --protocol-configuration '{"serverProtocol":"HTTP"}' \
+    --lifecycle-configuration '{"idleRuntimeSessionTimeout":300,"maxLifetime":3600}' \
+    --environment-variables \
+      STACK_NAME="${STACK_NAME}",AWS_REGION="${REGION}",S3_BUCKET="${S3_BUCKET}",\
+BEDROCK_MODEL_ID="${MODEL}",DYNAMODB_TABLE="${DYNAMODB_TABLE}",DYNAMODB_REGION="${DYNAMODB_REGION}" \
     --region "$REGION" &>/dev/null || warn "  Runtime update failed — may need manual update in console"
   RUNTIME_ID="$EXISTING_RUNTIME"
 else


### PR DESCRIPTION
## Summary
- preserve runtime configuration fields during `update-agent-runtime`
- pass the same protocol, lifecycle, and environment settings used during runtime creation

## Why
During redeploys, the existing update path only replaced the container image. Changes to `BEDROCK_MODEL_ID` and the other runtime environment variables were silently ignored, which left existing runtimes serving stale configuration.

## Validation
- reviewed the update path in `enterprise/deploy.sh`
- confirmed the patch is limited to the existing-runtime update branch
