### PR TITLE
Add Slack DM compatibility mappings during pairing approval

### DIFF
--- a/enterprise/admin-console/server/routers/bindings.py
+++ b/enterprise/admin-console/server/routers/bindings.py
@@ -156,6 +156,32 @@ class PairingApproveRequest(BaseModel):
     pairingUserId: str = ""   # username/handle (e.g. "wujiade4444") for dm_ mapping
 
 
+def _candidate_pairing_aliases(channel: str, pairing_user_id: str, employee_id: str) -> list[str]:
+    aliases: list[str] = []
+
+    def add(value: str):
+        value = (value or "").strip()
+        if not value or value in aliases:
+            return
+        aliases.append(value)
+
+    add(pairing_user_id)
+
+    # Slack DMs in this deployment are currently surfaced as "dm_<display name>"
+    # rather than the stable Slack user ID. When the operator leaves
+    # pairingUserId empty, synthesize a few likely aliases from the employee name
+    # so the initial mapping still works.
+    if channel == "slack" and not pairing_user_id:
+        emp = db.get_employee(employee_id)
+        name = emp.get("name", "") if emp else ""
+        parts = [p for p in re.split(r"\s+", name.strip()) if p]
+        if parts:
+            add(parts[0])
+            add("_".join(parts))
+            add("".join(parts))
+    return aliases
+
+
 # =========================================================================
 # Bindings CRUD
 # =========================================================================
@@ -303,12 +329,12 @@ def approve_pairing(body: PairingApproveRequest, authorization: str = Header(def
     mapping_written = False
     if body.channelUserId and body.employeeId:
         _write_user_mapping(body.channel, body.channelUserId, body.employeeId)
-        # Also write username-based mappings extracted by H2 Proxy from Discord DM format
-        if body.pairingUserId:  # Discord username from pairing message meta
-            _write_user_mapping(body.channel, f"dm_{body.pairingUserId}", body.employeeId)
-            _write_user_mapping(body.channel, body.pairingUserId, body.employeeId)
+        for alias in _candidate_pairing_aliases(body.channel, body.pairingUserId, body.employeeId):
+            _write_user_mapping(body.channel, f"dm_{alias}", body.employeeId)
+            _write_user_mapping(body.channel, alias, body.employeeId)
         # Position and permissions are now read from DynamoDB (EMP#/POS# records).
         # DynamoDB MAPPING# resolves channelUserId → emp_id → positionId at runtime.
+        mapping_written = True
 
     # 3. Sync updated allowFrom list to S3 so microVMs pick it up
     # The EC2's openclaw pairing approve updates the local credentials file.

--- a/enterprise/admin-console/server/routers/bindings.py
+++ b/enterprise/admin-console/server/routers/bindings.py
@@ -7,6 +7,7 @@ Extracted from main.py lines 699-1172.
 
 import os
 import json
+import re
 import threading
 import subprocess
 from datetime import datetime, timezone

--- a/enterprise/admin-console/src/pages/Bindings.tsx
+++ b/enterprise/admin-console/src/pages/Bindings.tsx
@@ -413,7 +413,7 @@ export default function Bindings() {
               <input value={pairUsername} onChange={e => setPairUsername(e.target.value)}
                 placeholder="e.g. wujiade4444"
                 className="w-full rounded-lg border border-dark-border bg-dark-bg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none font-mono" />
-              <p className="text-xs text-text-muted mt-1">Discord username shown in pairing message meta. Creates additional SSM mappings for reliable routing.</p>
+              <p className="text-xs text-text-muted mt-1">For Discord, use the username from pairing metadata. For Slack, use the DM display name if the runtime surfaces messages as <code>dm_name</code>. This creates compatibility mappings for reliable routing.</p>
             </div>
             <Select label="Employee" value={pairEmpId} onChange={setPairEmpId}
               options={EMPLOYEES.map(e => ({ label: `${e.name} (${e.positionName})`, value: e.id }))}


### PR DESCRIPTION
## Summary
- add Slack/Discord-compatible alias mappings when approving pairings
- synthesize likely Slack DM aliases from the employee name when pairing metadata does not include a username
- update the bindings UI helper text and fix the missing mappingWritten flag

## Why
In the current enterprise Slack flow, the runtime can surface DM senders as `dm_<display-name>` instead of the stable Slack user ID. The admin approval flow only persisted the raw channel user ID, so Slack pairings could look approved in the portal but still fail routing with "This account is not linked to an employee".

This change writes the compatibility aliases at approval time so the existing router can resolve the employee reliably.

## Validation
- `python3 -m py_compile enterprise/admin-console/server/routers/bindings.py`
- `git diff --check upstream/main...HEAD`
