### PR TITLE
Auto-configure Slack channel during enterprise EC2 setup

### DIFF
--- a/enterprise/ec2-setup.sh
+++ b/enterprise/ec2-setup.sh
@@ -183,7 +183,7 @@ if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_APP_TOKEN:-}" ]; then
     set -o allexport
     . /etc/openclaw/env
     set +o allexport
-    openclaw channels add --channel slack --use-env
+    openclaw channels add --channel slack --bot-token "$SLACK_BOT_TOKEN" --app-token "$SLACK_APP_TOKEN"
   ' || echo "  WARN: Slack channel configuration failed"
 fi
 

--- a/enterprise/ec2-setup.sh
+++ b/enterprise/ec2-setup.sh
@@ -171,6 +171,22 @@ sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user daemon-reload 
 sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart openclaw-gateway 2>/dev/null || true
 echo "  openclaw-gateway restarted"
 
+# Configure Slack from env when both Socket Mode tokens are present.
+# This keeps Slack setup reproducible across redeploys instead of relying on
+# one-time UI clicks on the gateway.
+if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_APP_TOKEN:-}" ]; then
+  echo "  Configuring Slack channel from env"
+  sudo -H -u ubuntu bash -lc '
+    export HOME=/home/ubuntu
+    export XDG_RUNTIME_DIR=/run/user/1000
+    source /home/ubuntu/.nvm/nvm.sh
+    set -o allexport
+    . /etc/openclaw/env
+    set +o allexport
+    openclaw channels add --channel slack --use-env
+  ' || echo "  WARN: Slack channel configuration failed"
+fi
+
 echo ""
 echo "══════════════════════════════════════════════════"
 echo "  EC2 Setup Complete!"


### PR DESCRIPTION
## Summary
- configure Slack automatically during EC2 setup when both Slack tokens are present
- pass the bot token and app token explicitly to `openclaw channels add`

## Why
The current enterprise deploy path can inject Slack env vars, but it still leaves Slack channel setup as a manual post-deploy step on the gateway host. In practice, using `--use-env` was also not reliably persisting both Slack tokens into the gateway channel config.

This makes Slack setup reproducible across redeploys and CI by configuring the channel during EC2 setup with the explicit Socket Mode credentials.

## Validation
- `bash -n enterprise/ec2-setup.sh`
- `git diff --check upstream/main...HEAD`
