### PR TITLE
Strip IM wrapper metadata before routing channel messages

### DIFF
--- a/enterprise/gateway/bedrock_proxy_h2.js
+++ b/enterprise/gateway/bedrock_proxy_h2.js
@@ -177,6 +177,36 @@ async function fastPathBedrock(userText) {
 // Message Extraction (unchanged from original)
 // =============================================================================
 
+function stripTrailingConversationMetadata(text) {
+  if (!text) return text;
+  return text
+    .replace(/\n{2,}Conversation info \(untrusted metadata\):[\s\S]*$/i, '')
+    .replace(/\n{2,}Sender \(untrusted metadata\):[\s\S]*$/i, '')
+    .trim();
+}
+
+function unwrapChannelMessage(text) {
+  if (!text) return text;
+
+  const patterns = [
+    /^System:\s*\[[^\]]+\]\s*Slack DM from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*Slack (?:message )?in #[^:]+ from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*Telegram (?:message |DM )?from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*Telegram (?:message )?in .+? from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*WhatsApp (?:message |DM )?from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*WhatsApp (?:message )?in .+? from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*Discord DM from [^:]+:\s*([\s\S]*)$/i,
+    /^System:\s*\[[^\]]+\]\s*Discord (?:message )?in #[^:]+ from [^:]+:\s*([\s\S]*)$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return stripTrailingConversationMetadata(match[1]);
+  }
+
+  return stripTrailingConversationMetadata(text);
+}
+
 function extractUserMessage(body) {
   const messages = body.messages || [];
   const systemParts = body.system || [];
@@ -194,13 +224,14 @@ function extractUserMessage(body) {
     }
   }
 
+  const originalUserText = userText;
   let channel = 'unknown';
   let userId = 'unknown';
 
   // Priority 0: Extract from OpenClaw's JSON metadata in message text
   // OpenClaw embeds sender info as JSON in the conversation context
   try {
-    const jsonMatch = userText.match(/```json\s*\n([\s\S]*?)\n```/);
+    const jsonMatch = originalUserText.match(/```json\s*\n([\s\S]*?)\n```/);
     if (jsonMatch) {
       const meta = JSON.parse(jsonMatch[1]);
       if (meta.sender_id) {
@@ -211,11 +242,11 @@ function extractUserMessage(body) {
           channel = metaChannel;
         } else if (meta.channel_type) {
           channel = meta.channel_type.toLowerCase();
-        } else if (userText.includes('Discord')) channel = 'discord';
-        else if (userText.includes('Telegram')) channel = 'telegram';
-        else if (userText.includes('Slack')) channel = 'slack';
-        else if (userText.includes('WhatsApp')) channel = 'whatsapp';
-        else if (userText.includes('Feishu') || userText.includes('feishu')) channel = 'feishu';
+        } else if (originalUserText.includes('Discord')) channel = 'discord';
+        else if (originalUserText.includes('Telegram')) channel = 'telegram';
+        else if (originalUserText.includes('Slack')) channel = 'slack';
+        else if (originalUserText.includes('WhatsApp')) channel = 'whatsapp';
+        else if (originalUserText.includes('Feishu') || originalUserText.includes('feishu')) channel = 'feishu';
         // Heuristic fallback: detect channel by sender_id format when no keyword found
         // Telegram user IDs are 7-12 digits; Discord IDs are 17-19 digits; WhatsApp uses +phone
         else if (/^\d{7,12}$/.test(meta.sender_id)) channel = 'telegram';
@@ -248,14 +279,14 @@ function extractUserMessage(body) {
   } catch (e) { /* fall through */ }
 
   // Priority 1: extract from user message text (original regex)
-  const slackDm = userText.match(/Slack DM from ([\w]+):/i);
-  const slackChan = userText.match(/Slack (?:message )?in #([\w-]+).*?from ([\w]+):/i);
-  const waDm = userText.match(/WhatsApp (?:message |DM )?from ([\w+\-.]+):/i);
-  const waGroup = userText.match(/WhatsApp (?:message )?in (.+?) from ([\w+\-.]+):/i);
-  const tgDm = userText.match(/Telegram (?:message |DM )?from ([\w]+):/i);
-  const tgGroup = userText.match(/Telegram (?:message )?in (.+?) from ([\w]+):/i);
-  const dcDm = userText.match(/Discord DM from ([\w#]+):/i);
-  const dcChan = userText.match(/Discord (?:message )?in #([\w-]+).*?from ([\w#]+):/i);
+  const slackDm = originalUserText.match(/Slack DM from ([\w]+):/i);
+  const slackChan = originalUserText.match(/Slack (?:message )?in #([\w-]+).*?from ([\w]+):/i);
+  const waDm = originalUserText.match(/WhatsApp (?:message |DM )?from ([\w+\-.]+):/i);
+  const waGroup = originalUserText.match(/WhatsApp (?:message )?in (.+?) from ([\w+\-.]+):/i);
+  const tgDm = originalUserText.match(/Telegram (?:message |DM )?from ([\w]+):/i);
+  const tgGroup = originalUserText.match(/Telegram (?:message )?in (.+?) from ([\w]+):/i);
+  const dcDm = originalUserText.match(/Discord DM from ([\w#]+):/i);
+  const dcChan = originalUserText.match(/Discord (?:message )?in #([\w-]+).*?from ([\w#]+):/i);
 
   if (slackChan) { channel = 'slack'; userId = 'chan_' + slackChan[1] + '_' + slackChan[2]; }
   else if (slackDm) { channel = 'slack'; userId = 'dm_' + slackDm[1]; }
@@ -280,6 +311,7 @@ function extractUserMessage(body) {
     }
   }
 
+  userText = unwrapChannelMessage(originalUserText);
   return { userText, channel, userId };
 }
 


### PR DESCRIPTION
## Summary
- extract sender/channel metadata from wrapped IM messages as before
- strip Slack/Telegram/WhatsApp/Discord wrapper text and trailing metadata before routing to the tenant router
- keep the routing identity logic intact while forwarding only the human message content

## Why
The enterprise gateway currently forwards channel wrapper text like `System: [timestamp] Slack DM from RJ: ...` plus the embedded metadata block into the employee session. In practice that can poison the conversation and produce Bedrock errors like `User messages cannot contain reasoning content` on later turns.

This change keeps the wrapper for sender detection but only routes the actual user message into AgentCore.

## Validation
- `node -c enterprise/gateway/bedrock_proxy_h2.js`
- live verification in the Agents Lab sandbox: replaying Slack-shaped wrapped messages through the Bedrock proxy no longer injects the wrapper into the routed turn
