### PR TITLE
fix: use OPENCLAW_STATE_DIR instead of symlink for data volume

### DIFF
--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -650,13 +650,25 @@ Resources:
                       mkfs.ext4 -L openclaw-data "$DATA_DEVICE"
                     fi
                     mkdir -p /data
-                    mount "$DATA_DEVICE" /data || true
+                    if ! mount "$DATA_DEVICE" /data; then
+                      echo "FATAL: failed to mount data volume $DATA_DEVICE at /data"
+                      exit 1
+                    fi
                     grep -q "$DATA_DEVICE" /etc/fstab || \
                       echo "$DATA_DEVICE /data ext4 defaults,nofail 0 2" >> /etc/fstab
                     mkdir -p /data/openclaw
                     chown ubuntu:ubuntu /data/openclaw
+                    # Keep ~/.openclaw symlink for CLI convenience (e.g. 'ls ~/.openclaw').
+                    # Set OPENCLAW_STATE_DIR to the real path so OpenClaw's exec approval
+                    # boundary check never traverses the symlink.
                     [ -L /home/ubuntu/.openclaw ] || ln -sf /data/openclaw /home/ubuntu/.openclaw
+                    mkdir -p /home/ubuntu/.config/environment.d
+                    echo "OPENCLAW_STATE_DIR=/data/openclaw" >> /home/ubuntu/.config/environment.d/openclaw.conf
+                  else
+                    echo "FATAL: no data volume found — expected an EBS volume attached at /dev/nvme1n1, /dev/xvdf, or /dev/sdf"
+                    exit 1
                   fi
+                  STATE_DIR=/data/openclaw
 
                   # System update
                   echo "[1/9] Updating system..."
@@ -778,7 +790,17 @@ Resources:
                     echo "export AWS_PROFILE=default"
                     echo "export OPENCLAW_MODEL=${OpenClawModel}"
                     echo "export OPENCLAW_USE_BEDROCK=true"
+                    echo "export OPENCLAW_STATE_DIR=/data/openclaw"
                   } >> /home/ubuntu/.bashrc
+
+                  # Also add to .profile so OPENCLAW_STATE_DIR is available in
+                  # non-interactive login shells (e.g. 'sudo su - ubuntu')
+                  echo "export OPENCLAW_STATE_DIR=/data/openclaw" >> /home/ubuntu/.profile
+                  chown ubuntu:ubuntu /home/ubuntu/.profile
+
+                  # Ensure .config is ubuntu-owned before gateway install runs
+                  mkdir -p /home/ubuntu/.config/systemd/user
+                  chown -R ubuntu:ubuntu /home/ubuntu/.config
 
                   sudo -u ubuntu mkdir -p /home/ubuntu/.config/environment.d
                   sudo -u ubuntu bash -c "{ echo AWS_REGION=$AWS_REGION; echo AWS_DEFAULT_REGION=$AWS_REGION; echo AWS_PROFILE=default; } > /home/ubuntu/.config/environment.d/aws.conf"
@@ -788,12 +810,12 @@ Resources:
 
                   # Configure OpenClaw
                   echo "[8/9] Configuring OpenClaw..."
-                  sudo -u ubuntu mkdir -p /home/ubuntu/.openclaw
+                  sudo -u ubuntu mkdir -p "$STATE_DIR"
 
                   # Write .env for Bedrock IAM auth — survives gateway install/reinstall
                   # OpenClaw 2026.4.5+ uses pi-coding-agent which needs AWS_PROFILE
                   # to discover IAM credentials from EC2 instance profile (IMDS)
-                  sudo -u ubuntu bash -c "printf 'AWS_PROFILE=default\nAWS_REGION=$AWS_REGION\nAWS_DEFAULT_REGION=$AWS_REGION\n' > /home/ubuntu/.openclaw/.env"
+                  sudo -u ubuntu bash -c "printf 'AWS_PROFILE=default\nAWS_REGION=$AWS_REGION\nAWS_DEFAULT_REGION=$AWS_REGION\n' > $STATE_DIR/.env"
 
                   GATEWAY_TOKEN=$(openssl rand -hex 24)
 
@@ -803,15 +825,15 @@ Resources:
                   OPENCLAW_VERSION="${OpenClawVersion}"
                   if [ "$OPENCLAW_VERSION" = "2026.3.24" ]; then
                     echo "Using legacy config (models.providers) for $OPENCLAW_VERSION"
-                    cp /opt/openclaw/openclaw-config-legacy.json /home/ubuntu/.openclaw/openclaw.json
-                    sed -i "s/REGION_PLACEHOLDER/$AWS_REGION/g" /home/ubuntu/.openclaw/openclaw.json
+                    cp /opt/openclaw/openclaw-config-legacy.json "$STATE_DIR/openclaw.json"
+                    sed -i "s/REGION_PLACEHOLDER/$AWS_REGION/g" "$STATE_DIR/openclaw.json"
                   else
                     echo "Using modern config (plugins.discovery) for $OPENCLAW_VERSION"
-                    cp /opt/openclaw/openclaw-config-modern.json /home/ubuntu/.openclaw/openclaw.json
+                    cp /opt/openclaw/openclaw-config-modern.json "$STATE_DIR/openclaw.json"
                   fi
-                  chown ubuntu:ubuntu /home/ubuntu/.openclaw/openclaw.json
-                  sed -i "s/GATEWAY_TOKEN_PLACEHOLDER/$GATEWAY_TOKEN/g" /home/ubuntu/.openclaw/openclaw.json
-                  sed -i "s|MODEL_ID_PLACEHOLDER|${OpenClawModel}|g" /home/ubuntu/.openclaw/openclaw.json
+                  chown ubuntu:ubuntu "$STATE_DIR/openclaw.json"
+                  sed -i "s/GATEWAY_TOKEN_PLACEHOLDER/$GATEWAY_TOKEN/g" "$STATE_DIR/openclaw.json"
+                  sed -i "s|MODEL_ID_PLACEHOLDER|${OpenClawModel}|g" "$STATE_DIR/openclaw.json"
 
                   # Install and start gateway
                   for i in $(seq 1 15); do
@@ -823,8 +845,9 @@ Resources:
                     sleep 2
                   done
 
-                  sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus bash -c '
+                  sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus OPENCLAW_STATE_DIR="$STATE_DIR" bash -c '
                   export HOME=/home/ubuntu
+                  export OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR
                   export NVM_DIR="$HOME/.nvm"
                   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
                   openclaw gateway install || echo "Gateway install failed"
@@ -868,8 +891,8 @@ Resources:
                   '
 
                   # Copy SOUL.md
-                  cp /opt/openclaw/SOUL.md /home/ubuntu/.openclaw/SOUL.md
-                  chown ubuntu:ubuntu /home/ubuntu/.openclaw/SOUL.md
+                  cp /opt/openclaw/SOUL.md "$STATE_DIR/SOUL.md"
+                  chown ubuntu:ubuntu "$STATE_DIR/SOUL.md"
 
                   # Save token to SSM Parameter Store
                   STACK_NAME="${AWS::StackName}"
@@ -882,8 +905,8 @@ Resources:
                   unset GATEWAY_TOKEN
 
                   # Save instance info
-                  echo "$INSTANCE_ID" > /home/ubuntu/.openclaw/instance_id.txt
-                  echo "$AWS_REGION" > /home/ubuntu/.openclaw/region.txt
+                  echo "$INSTANCE_ID" > "$STATE_DIR/instance_id.txt"
+                  echo "$AWS_REGION" > "$STATE_DIR/region.txt"
 
                   # Copy SSM access script
                   cp /opt/openclaw/ssm-portforward.sh /home/ubuntu/ssm-portforward.sh
@@ -891,8 +914,8 @@ Resources:
 
                   # Signal CloudFormation
                   echo "[9/9] Signaling CloudFormation..."
-                  echo "SUCCESS" > /home/ubuntu/.openclaw/setup_status.txt
-                  echo "Setup completed: $(date)" >> /home/ubuntu/.openclaw/setup_status.txt
+                  echo "SUCCESS" > "$STATE_DIR/setup_status.txt"
+                  echo "Setup completed: $(date)" >> "$STATE_DIR/setup_status.txt"
 
                   # Read token back from SSM for cfn-signal (so CloudFormation Outputs can build the access URL)
                   CFN_TOKEN=$(aws ssm get-parameter --name "/openclaw/$STACK_NAME/gateway-token" --with-decryption --query Parameter.Value --output text --region $AWS_REGION 2>/dev/null || echo "TOKEN_UNAVAILABLE")


### PR DESCRIPTION
## Problem

The CloudFormation template mounts the data volume at `/data/openclaw` and then creates a symlink `~/.openclaw → /data/openclaw`. OpenClaw's exec approval path check uses `realpathSync`-based boundary verification and rejects symlink traversal by design, which blocks all exec commands on the running instance.

## Changes

- **Replace symlink with `OPENCLAW_STATE_DIR`**: set `OPENCLAW_STATE_DIR=/data/openclaw` via `environment.d`, `.bashrc`, and `.profile` so OpenClaw uses the real path directly. The `~/.openclaw` symlink is retained for CLI convenience (`ls ~/.openclaw`, etc.) — it does not affect OpenClaw's internal path resolution when `OPENCLAW_STATE_DIR` is set.
- **Hard fail on missing/unmountable volume**: replace `mount ... || true` with an explicit failure + clear error message, and add an `else` branch if no data device is found. This is always-on infrastructure; silent fallback to the wrong directory is worse than a clear setup failure.
- **Fix `.config` ownership**: `mkdir -p /home/ubuntu/.config/systemd/user && chown -R ubuntu:ubuntu /home/ubuntu/.config` before `openclaw gateway install` runs, preventing an `EACCES` failure when the setup script runs as root.
- **Export `OPENCLAW_STATE_DIR` for SSH sessions**: add to `.bashrc` and `.profile` so `openclaw logs`, `openclaw gateway status`, etc. work correctly out of the box when SSHing in as ubuntu.

## Testing

Deployed and verified end-to-end on a fresh `t4g.medium` stack in `us-west-2`:
- Gateway starts correctly with state in `/data/openclaw`
- `openclaw logs --follow` works from SSH session without manual env prefix
- `OPENCLAW_STATE_DIR=/data/openclaw` confirmed in gateway process environment
- Symlink `~/.openclaw → /data/openclaw` present and usable for CLI navigation