### PR TITLE
feat: Fargate frontend overhaul — dual Agent architecture

### DIFF
--- a/enterprise/admin-console/src/App.tsx
+++ b/enterprise/admin-console/src/App.tsx
@@ -82,7 +82,6 @@ function AppRoutes() {
       <Route path="/portal/requests" element={user ? <PortalLayout><PortalMyRequests /></PortalLayout> : <Navigate to="/login" replace />} />
       <Route path="/portal/channels" element={user ? <PortalLayout><PortalBindIM /></PortalLayout> : <Navigate to="/login" replace />} />
       <Route path="/portal/agents" element={user ? <PortalLayout><PortalMyAgents /></PortalLayout> : <Navigate to="/login" replace />} />
-      <Route path="/portal/chat" element={user ? <PortalLayout><PortalChat /></PortalLayout> : <Navigate to="/login" replace />} />
 
       {/* Admin/Manager Console */}
       <Route path="/" element={user ? <Navigate to={user.role === 'employee' ? '/portal' : '/dashboard'} replace /> : <Navigate to="/login" replace />} />

--- a/enterprise/admin-console/src/components/PortalLayout.tsx
+++ b/enterprise/admin-console/src/components/PortalLayout.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { MessageSquare, User, BarChart3, Puzzle, FileText, LogOut, Sun, Moon, Link2, ArrowLeft, Bot } from 'lucide-react';
+import { MessageSquare, User, BarChart3, Puzzle, FileText, LogOut, Sun, Moon, Link2, ArrowLeft, Bot, Zap, Radio } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { PortalAgentProvider, usePortalAgent } from '../contexts/PortalAgentContext';
 import { api } from '../api/client';
 import ClawForgeLogo from './ClawForgeLogo';
 import clsx from 'clsx';
@@ -18,8 +19,17 @@ const NAV = [
 ];
 
 export default function PortalLayout({ children }: { children: ReactNode }) {
+  return (
+    <PortalAgentProvider>
+      <PortalLayoutInner>{children}</PortalLayoutInner>
+    </PortalAgentProvider>
+  );
+}
+
+function PortalLayoutInner({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
+  const { agentType, setAgentType, hasAlwaysOn, alwaysOnInfo, loading: aoLoading } = usePortalAgent();
   const navigate = useNavigate();
   const location = useLocation();
   const [pendingCount, setPendingCount] = useState(0);
@@ -44,6 +54,48 @@ export default function PortalLayout({ children }: { children: ReactNode }) {
             <div className="text-xs text-text-muted">{user?.name || 'Employee'}</div>
           </div>
         </div>
+
+        {/* Agent Switcher */}
+        {!aoLoading && (
+          <div className="px-3 pt-3 pb-1">
+            <p className="text-[10px] font-medium text-text-muted uppercase tracking-wider mb-1.5 px-1">Active Agent</p>
+            <div className="space-y-1">
+              <button
+                onClick={() => setAgentType('serverless')}
+                className={clsx(
+                  'flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-xs transition-colors',
+                  agentType === 'serverless'
+                    ? 'bg-primary/10 border border-primary/30 text-primary-light font-medium'
+                    : 'text-text-muted hover:bg-dark-hover hover:text-text-primary border border-transparent'
+                )}
+              >
+                <Radio size={14} />
+                <span className="flex-1 text-left">Serverless</span>
+                {agentType === 'serverless' && <span className="w-1.5 h-1.5 rounded-full bg-primary" />}
+              </button>
+              {hasAlwaysOn ? (
+                <button
+                  onClick={() => setAgentType('always-on')}
+                  className={clsx(
+                    'flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-xs transition-colors',
+                    agentType === 'always-on'
+                      ? 'bg-success/10 border border-success/30 text-success font-medium'
+                      : 'text-text-muted hover:bg-dark-hover hover:text-text-primary border border-transparent'
+                  )}
+                >
+                  <Zap size={14} />
+                  <span className="flex-1 text-left">Always-On{alwaysOnInfo?.tier ? ` · ${alwaysOnInfo.tier}` : ''}</span>
+                  {alwaysOnInfo?.running && <span className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />}
+                </button>
+              ) : (
+                <div className="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs text-text-muted/50 border border-transparent">
+                  <Zap size={14} />
+                  <span className="flex-1">Always-On · Not configured</span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* Nav */}
         <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-1">

--- a/enterprise/admin-console/src/contexts/PortalAgentContext.tsx
+++ b/enterprise/admin-console/src/contexts/PortalAgentContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import { api } from '../api/client';
+import { useAuth } from './AuthContext';
+
+type AgentType = 'serverless' | 'always-on';
+
+interface PortalAgentContextValue {
+  agentType: AgentType;
+  setAgentType: (t: AgentType) => void;
+  hasAlwaysOn: boolean;
+  alwaysOnInfo: { tier?: string; status?: string; endpoint?: string; running?: boolean } | null;
+  loading: boolean;
+}
+
+const PortalAgentContext = createContext<PortalAgentContextValue>({
+  agentType: 'serverless',
+  setAgentType: () => {},
+  hasAlwaysOn: false,
+  alwaysOnInfo: null,
+  loading: true,
+});
+
+export function PortalAgentProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [agentType, setAgentType] = useState<AgentType>('serverless');
+  const [hasAlwaysOn, setHasAlwaysOn] = useState(false);
+  const [alwaysOnInfo, setAlwaysOnInfo] = useState<PortalAgentContextValue['alwaysOnInfo']>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    api.get<any>('/portal/my-agents').then(d => {
+      const ao = d?.alwaysOn;
+      if (ao?.enabled) {
+        setHasAlwaysOn(true);
+        setAlwaysOnInfo({
+          tier: ao.tier,
+          status: ao.status || ao.ecsStatus,
+          endpoint: ao.endpoint,
+          running: ao.status === 'running' || ao.running,
+        });
+      }
+      setLoading(false);
+    }).catch(() => setLoading(false));
+  }, [user?.id]);
+
+  return (
+    <PortalAgentContext.Provider value={{ agentType, setAgentType, hasAlwaysOn, alwaysOnInfo, loading }}>
+      {children}
+    </PortalAgentContext.Provider>
+  );
+}
+
+export function usePortalAgent() {
+  return useContext(PortalAgentContext);
+}

--- a/enterprise/admin-console/src/hooks/useApi.ts
+++ b/enterprise/admin-console/src/hooks/useApi.ts
@@ -515,10 +515,10 @@ export function useSaveSoul() {
 
 // === Workspace file operations ===
 
-export function useWorkspaceTree(agentId: string) {
+export function useWorkspaceTree(agentId: string, agentType?: 'serverless' | 'always-on') {
   return useQuery({
-    queryKey: ['workspace-tree', agentId],
-    queryFn: () => api.get(`/workspace/tree?agent_id=${agentId}`),
+    queryKey: ['workspace-tree', agentId, agentType],
+    queryFn: () => api.get(`/workspace/tree?agent_id=${agentId}${agentType ? `&agent_type=${agentType}` : ''}`),
     enabled: !!agentId,
   });
 }
@@ -1205,7 +1205,12 @@ export function useAlwaysOnStatus(empId: string) {
     queryKey: ['always-on-status', empId],
     queryFn: () => api.get(`/agents/${empId}/always-on/status`),
     enabled: !!empId,
-    refetchInterval: 30000,
+    refetchInterval: (query) => {
+      const data = query.state.data as any;
+      // Poll faster (5s) when container is starting/stopping, slower (30s) when stable
+      const status = data?.ecsStatus || data?.status;
+      return status === 'starting' || status === 'stopping' || status === 'PROVISIONING' ? 5000 : 30000;
+    },
   });
 }
 

--- a/enterprise/admin-console/src/pages/AgentFactory/AgentDetail.tsx
+++ b/enterprise/admin-console/src/pages/AgentFactory/AgentDetail.tsx
@@ -2,9 +2,9 @@ import { useParams, useNavigate } from 'react-router-dom';
 import Chart from 'react-apexcharts';
 import type { ApexOptions } from 'apexcharts';
 import { useState } from 'react';
-import { ArrowLeft, Edit3, MessageSquare, Eye, Loader, FolderOpen, RefreshCw, Trash2 } from 'lucide-react';
-import { Card, Badge, Button, PageHeader, StatusDot, Modal } from '../../components/ui';
-import { useAgent, useAgents, usePositions, useBindings, useSessions, useAgentDailyUsage, useAlwaysOnStatus, useAlwaysOnChannels, useEnableAlwaysOn, useDisconnectChannel } from '../../hooks/useApi';
+import { ArrowLeft, Edit3, MessageSquare, Eye, Loader, FolderOpen, RefreshCw, Trash2, Zap, AlertTriangle, Shield, Radio, Clock, Link2 } from 'lucide-react';
+import { Card, Badge, Button, PageHeader, StatusDot, Modal, Tabs } from '../../components/ui';
+import { useAgent, useAgents, usePositions, useEmployees, useBindings, useSessions, useAgentDailyUsage, useAlwaysOnStatus, useAlwaysOnChannels, useEnableAlwaysOn, useDisconnectChannel, useSecurityRuntimes, usePositionRuntimeMap, useModelConfig, useAuditEntries, useSetIMPlatforms } from '../../hooks/useApi';
 import { api } from '../../api/client';
 import { CHANNEL_LABELS } from '../../types';
 import type { ChannelType } from '../../types';
@@ -44,11 +44,31 @@ export default function AgentDetail() {
   const { data: dailyUsage = [] } = useAgentDailyUsage(agentId || '');
   const [showDelete, setShowDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [agentTab, setAgentTab] = useState<'serverless' | 'always-on'>('serverless');
+  const { data: auditData = [] } = useAuditEntries({ limit: 20 });
+  const setIMPlatforms = useSetIMPlatforms();
+  const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null);
   const empId = agent?.employeeId || '';
   const { data: aoStatus } = useAlwaysOnStatus(empId) as { data: any };
   const { data: aoChannels } = useAlwaysOnChannels(empId) as { data: any };
   const enableAO = useEnableAlwaysOn();
   const disconnectCh = useDisconnectChannel();
+  const { data: runtimesData } = useSecurityRuntimes() as { data: any };
+  const { data: posRuntimeMap } = usePositionRuntimeMap() as { data: any };
+  const { data: mc } = useModelConfig() as { data: any };
+  const { data: employees = [] } = useEmployees();
+  const runtimes = (runtimesData as any)?.runtimes || [];
+  const models = mc?.availableModels || [];
+  // Lookup tier runtime config
+  const tierRuntime = runtimes.find((rt: any) => {
+    const posId = agent?.positionId || '';
+    const mapped = posId ? (posRuntimeMap as any)?.map?.[posId] : undefined;
+    return mapped === rt.id || rt.name?.toLowerCase().includes(aoStatus?.tier?.toLowerCase());
+  });
+  const tierModel = tierRuntime ? (models.find((m: any) => m.modelId === tierRuntime.model)?.modelName || tierRuntime.model?.split('/').pop()?.split(':')[0] || '—') : '—';
+  // Position change detection
+  const currentEmployee = employees.find((e: any) => e.id === empId);
+  const positionMismatch = agent && currentEmployee && agent.positionId !== currentEmployee.positionId;
 
   if (isLoading) {
     return <div className="flex items-center justify-center py-20"><Loader size={24} className="animate-spin text-primary" /></div>;
@@ -98,8 +118,8 @@ export default function AgentDetail() {
           <div className="mt-1"><StatusDot status={agent.status} /></div>
         </Card>
         <Card>
-          <p className="text-xs text-text-muted">Quality Score</p>
-          <p className="mt-1 text-xl font-bold text-warning">⭐ {agent.qualityScore || '—'}</p>
+          <p className="text-xs text-text-muted">Deploy Mode</p>
+          <p className="mt-1 text-sm font-bold">{aoStatus?.enabled ? <><Zap size={14} className="inline text-success mr-1" />Dual Agent</> : <><Radio size={14} className="inline text-primary mr-1" />Serverless</>}</p>
         </Card>
         <Card>
           <p className="text-xs text-text-muted">Skills</p>
@@ -114,10 +134,173 @@ export default function AgentDetail() {
           <p className="mt-1 text-xl font-bold text-success">{sessions.length}</p>
         </Card>
         <Card>
-          <p className="text-xs text-text-muted">Bindings</p>
-          <p className="mt-1 text-xl font-bold">{bindings.length}</p>
+          <p className="text-xs text-text-muted">Quality</p>
+          <p className="mt-1 text-xl font-bold text-warning">⭐ {agent.qualityScore || '—'}</p>
         </Card>
       </div>
+
+      {/* ── Dual Agent Tabs ── */}
+      <Card className="mb-6">
+        <Tabs
+          tabs={[
+            { id: 'serverless', label: '📡 Serverless Agent' },
+            ...(aoStatus?.enabled ? [{ id: 'always-on', label: '⚡ Always-On Agent' }] : []),
+          ]}
+          activeTab={agentTab}
+          onChange={t => setAgentTab(t as any)}
+        />
+
+        <div className="mt-4">
+          {/* ── SERVERLESS TAB ── */}
+          {agentTab === 'serverless' && (
+            <div className="space-y-4">
+              <div className="rounded-xl bg-primary/5 border border-primary/20 px-4 py-3 flex items-center gap-3">
+                <Radio size={16} className="text-primary shrink-0" />
+                <div className="flex-1">
+                  <p className="text-sm font-medium text-text-primary">Serverless Agent — AgentCore microVM</p>
+                  <p className="text-xs text-text-muted">On-demand execution via shared infrastructure. Storage: S3. ~10s cold start.</p>
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => navigate(`/workspace?agent=${agent.id}`)}>
+                  <FolderOpen size={12} /> S3 Workspace
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* ── ALWAYS-ON TAB ── */}
+          {agentTab === 'always-on' && aoStatus?.enabled && (
+            <div className="space-y-4">
+              {/* Position change warning */}
+              {positionMismatch && (
+                <div className="flex items-start gap-3 rounded-xl bg-warning/10 border border-warning/30 px-4 py-3">
+                  <AlertTriangle size={16} className="text-warning mt-0.5 shrink-0" />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-text-primary">Position Changed — Container Needs Restart</p>
+                    <p className="text-xs text-text-muted mt-0.5">
+                      Employee moved from <strong>{agent?.positionName}</strong> to <strong>{currentEmployee?.positionName}</strong>.
+                    </p>
+                  </div>
+                  <Button size="sm" variant="danger" onClick={() => api.post(`/agents/${empId}/always-on/restart`, {}).then(() => window.location.reload())}>
+                    <RefreshCw size={12} /> Restart Now
+                  </Button>
+                </div>
+              )}
+
+              {/* Fargate status */}
+              <div className="rounded-xl bg-success/5 border border-success/20 px-4 py-3 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Zap size={16} className="text-success shrink-0" />
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">Always-On Agent — ECS Fargate</p>
+                    <p className="text-xs text-text-muted">24/7 container · EFS persistent storage · HEARTBEAT enabled</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge color={aoStatus.running ? 'success' : 'danger'}>{aoStatus.running ? 'Running' : aoStatus.ecsStatus || 'Stopped'}</Badge>
+                  <Button size="sm" variant="ghost" onClick={() => api.post(`/agents/${empId}/always-on/restart`, {}).then(() => window.location.reload())}><RefreshCw size={12} /> Restart</Button>
+                  <Button size="sm" variant="ghost" className="text-danger" onClick={() => enableAO.mutate({ empId, enable: false })}>Stop</Button>
+                  <Button size="sm" variant="ghost" onClick={() => navigate(`/workspace?agent=${agent.id}&type=always-on`)}><FolderOpen size={12} /> EFS Workspace</Button>
+                </div>
+              </div>
+
+              {/* Runtime config grid */}
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                {[
+                  { label: 'Tier', value: aoStatus.tier },
+                  { label: 'Model', value: tierModel },
+                  { label: 'IAM Role', value: tierRuntime?.roleArn?.split('/').pop() || '—' },
+                  { label: 'Guardrail', value: tierRuntime?.guardrailId || 'None' },
+                  { label: 'Service', value: aoStatus.serviceName || '—' },
+                  { label: 'Endpoint', value: aoStatus.endpoint || '—' },
+                  { label: 'Est. Cost', value: `~$${aoStatus.tier === 'executive' || aoStatus.tier === 'engineering' ? '16' : '7'}/mo` },
+                  { label: 'Storage', value: 'EFS (Persistent)' },
+                ].map(r => (
+                  <div key={r.label} className="rounded-lg bg-dark-bg px-3 py-2">
+                    <p className="text-[10px] text-text-muted">{r.label}</p>
+                    <p className="text-xs font-mono text-text-secondary truncate">{r.value}</p>
+                  </div>
+                ))}
+              </div>
+
+              {/* P1-A: IM Whitelist + Connections */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-semibold text-text-primary flex items-center gap-2"><Link2 size={14} /> IM Channel Management</h4>
+                </div>
+
+                {/* Allowed platforms from position */}
+                <div className="rounded-lg bg-surface-dim px-3 py-2">
+                  <p className="text-[10px] text-text-muted mb-1.5">Allowed Platforms (from position: {agent.positionName})</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {['feishu', 'telegram', 'slack', 'discord', 'dingtalk', 'whatsapp'].map(p => {
+                      const allowed = (position as any)?.allowedIMPlatforms;
+                      const isAllowed = !allowed || allowed.length === 0 || allowed.includes(p);
+                      return (
+                        <span key={p} className={`text-[10px] px-2 py-0.5 rounded-full ${isAllowed ? 'bg-success/10 text-success' : 'bg-dark-bg text-text-muted line-through'}`}>
+                          {isAllowed ? '✓' : '✗'} {p}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Connected channels */}
+                {(aoChannels?.channels || []).length === 0 ? (
+                  <p className="text-xs text-text-muted py-2">No IM channels connected. Employee can connect via Portal → Connect IM.</p>
+                ) : (
+                  <div className="space-y-1.5">
+                    {(aoChannels?.channels || []).map((ch: any) => (
+                      <div key={ch.channel} className="flex items-center justify-between rounded-lg bg-dark-bg px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <Badge color="success">{ch.channel}</Badge>
+                          <span className="text-xs text-text-muted">Connected {ch.connectedAt ? new Date(ch.connectedAt).toLocaleDateString() : ''}</span>
+                        </div>
+                        {confirmDisconnect === ch.channel ? (
+                          <div className="flex items-center gap-1.5">
+                            <span className="text-[10px] text-danger">Confirm?</span>
+                            <Button variant="danger" size="sm" onClick={() => { disconnectCh.mutate({ empId, channel: ch.channel }); setConfirmDisconnect(null); }}>Yes</Button>
+                            <Button variant="ghost" size="sm" onClick={() => setConfirmDisconnect(null)}>No</Button>
+                          </div>
+                        ) : (
+                          <Button variant="ghost" size="sm" className="text-danger" onClick={() => setConfirmDisconnect(ch.channel)}>
+                            Disconnect
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* P1-B: IM Audit log inline */}
+                <div className="rounded-lg bg-surface-dim px-3 py-2">
+                  <p className="text-[10px] text-text-muted mb-1.5">Recent IM Events</p>
+                  {(() => {
+                    const imEvents = auditData.filter(e =>
+                      (e.actorName === agent.employeeName || e.detail?.includes(empId)) &&
+                      (['im_channel_connected', 'im_channel_disconnected', 'always_on_enabled', 'always_on_disabled', 'config_change'].includes(e.eventType))
+                    ).slice(0, 5);
+                    return imEvents.length === 0 ? (
+                      <p className="text-xs text-text-muted">No IM events recorded yet.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {imEvents.map((e, i) => (
+                          <div key={i} className="flex items-center gap-2 text-xs">
+                            <span className="text-text-muted w-16 shrink-0">{new Date(e.timestamp).toLocaleTimeString()}</span>
+                            <Badge color={e.eventType.includes('connected') || e.eventType.includes('enabled') ? 'success' : 'danger'}>
+                              {e.eventType.replace(/_/g, ' ')}
+                            </Badge>
+                            <span className="text-text-secondary truncate">{e.detail}</span>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })()}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </Card>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3 mb-6">
         {/* Activity Stats */}
@@ -216,81 +399,7 @@ export default function AgentDetail() {
         </Card>
       </div>
 
-      {/* Always-On Agent */}
-      <Card className="mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-text-primary">Always-On Agent (Fargate)</h3>
-          {aoStatus?.enabled ? (
-            <div className="flex items-center gap-2">
-              <Badge color={aoStatus.running ? 'success' : 'danger'}>
-                {aoStatus.running ? 'Running' : aoStatus.ecsStatus || 'Stopped'}
-              </Badge>
-              <Badge>{aoStatus.tier} tier</Badge>
-              <Button variant="default" size="sm" onClick={() => enableAO.mutate({ empId, enable: false })}>
-                Stop
-              </Button>
-            </div>
-          ) : (
-            <Button variant="primary" size="sm" onClick={() => enableAO.mutate({ empId, enable: true })}
-              disabled={enableAO.isPending}>
-              {enableAO.isPending ? 'Starting...' : 'Enable Always-On'}
-            </Button>
-          )}
-        </div>
-
-        {!aoStatus?.enabled && (
-          <p className="text-sm text-text-muted">
-            Always-on mode gives this employee a dedicated Fargate container with instant response,
-            persistent IM connections, and HEARTBEAT support. ~$7-16/month.
-          </p>
-        )}
-
-        {aoStatus?.enabled && (
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-              <div className="rounded-lg bg-dark-bg px-3 py-2">
-                <p className="text-xs text-text-muted">Tier</p>
-                <p className="text-sm font-semibold">{aoStatus.tier}</p>
-              </div>
-              <div className="rounded-lg bg-dark-bg px-3 py-2">
-                <p className="text-xs text-text-muted">Service</p>
-                <p className="text-sm font-mono text-text-secondary">{aoStatus.serviceName || '—'}</p>
-              </div>
-              <div className="rounded-lg bg-dark-bg px-3 py-2">
-                <p className="text-xs text-text-muted">Status</p>
-                <p className="text-sm font-semibold">{aoStatus.ecsStatus}</p>
-              </div>
-              <div className="rounded-lg bg-dark-bg px-3 py-2">
-                <p className="text-xs text-text-muted">Endpoint</p>
-                <p className="text-sm font-mono text-text-secondary truncate">{aoStatus.endpoint || '—'}</p>
-              </div>
-            </div>
-
-            {/* IM Connections */}
-            <div>
-              <p className="text-sm font-medium text-text-primary mb-2">IM Connections</p>
-              {(aoChannels?.channels || []).length === 0 ? (
-                <p className="text-xs text-text-muted">No IM channels connected. Employee can connect via Portal → My Agents.</p>
-              ) : (
-                <div className="space-y-2">
-                  {(aoChannels?.channels || []).map((ch: any) => (
-                    <div key={ch.channel} className="flex items-center justify-between rounded-lg bg-dark-bg px-3 py-2">
-                      <div className="flex items-center gap-2">
-                        <Badge color="success">{ch.channel}</Badge>
-                        <span className="text-xs text-text-muted">Connected {ch.connectedAt ? new Date(ch.connectedAt).toLocaleDateString() : ''}</span>
-                      </div>
-                      <Button variant="ghost" size="sm"
-                        onClick={() => disconnectCh.mutate({ empId, channel: ch.channel })}>
-                        Disconnect
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </Card>
+      {/* (Always-On section moved into tabs above) */}
 
       {/* Active Sessions */}
       {sessions.length > 0 && (

--- a/enterprise/admin-console/src/pages/AgentFactory/AgentList.tsx
+++ b/enterprise/admin-console/src/pages/AgentFactory/AgentList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bot, Plus, Users, Star, Zap, Edit3, Play, Settings, Eye, Search, Filter, Cpu, SlidersHorizontal, Trash2, RefreshCw, Check } from 'lucide-react';
 import { Card, StatCard, Badge, Button, PageHeader, Table as DataTable, Modal, Input, Select, StatusDot, Tabs } from '../../components/ui';
-import { useAgents, usePositions, useEmployees, useCreateAgent, useModelConfig, useUpdateModelConfig, useUpdateFallbackModel, useSetPositionModel, useRemovePositionModel, useSetEmployeeModel, useRemoveEmployeeModel, useAgentConfig, useSetPositionAgentConfig, useSetEmployeeAgentConfig } from '../../hooks/useApi';
+import { useAgents, usePositions, useEmployees, useCreateAgent, useModelConfig, useUpdateModelConfig, useUpdateFallbackModel, useSetPositionModel, useRemovePositionModel, useSetEmployeeModel, useRemoveEmployeeModel, useAgentConfig, useSetPositionAgentConfig, useSetEmployeeAgentConfig, useSecurityRuntimes, usePositionRuntimeMap } from '../../hooks/useApi';
 import { CHANNEL_LABELS } from '../../types';
 import type { Agent, ChannelType } from '../../types';
 
@@ -51,6 +51,10 @@ export default function AgentList() {
   const [newEmp, setNewEmp] = useState('');
   const [newChannels, setNewChannels] = useState<string[]>(['discord']);
   const [newDeployMode, setNewDeployMode] = useState<'serverless' | 'always-on-ecs'>('serverless');
+  const [newTier, setNewTier] = useState('');
+  const { data: runtimesData } = useSecurityRuntimes();
+  const { data: posRuntimeMap } = usePositionRuntimeMap();
+  const runtimes = (runtimesData as any)?.runtimes || [];
   const [filterText, setFilterText] = useState('');
   const [filterDept, setFilterDept] = useState('all');
   const [filterStatus, setFilterStatus] = useState('all');
@@ -226,7 +230,15 @@ export default function AgentList() {
                         {isOn && <Badge color="info" dot>{isStarting ? 'Starting…' : 'Always-on'}</Badge>}
                         {a.employeeId && <Badge color="default">{a.employeeName || a.employeeId}</Badge>}
                       </div>
-                      <p className="text-xs text-text-muted">{a.positionName} · ECS Fargate{a.ecsServiceName ? ` · ${a.ecsServiceName}` : ''}</p>
+                      <p className="text-xs text-text-muted">
+                        {a.positionName} · ECS Fargate
+                        {(() => {
+                          const rt = runtimes.find((r: any) => r.name?.toLowerCase().includes(a.positionName?.toLowerCase().split(' ')[0]));
+                          const model = rt ? (m.availableModels?.find((mo: any) => mo.modelId === rt.model)?.modelName || rt.model?.split('/').pop()?.split(':')[0]) : null;
+                          return model ? ` · ${model}` : '';
+                        })()}
+                        {` · ~$${a.positionName?.toLowerCase().includes('exec') || a.positionName?.toLowerCase().includes('engineer') ? '16' : '7'}/mo`}
+                      </p>
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       <Button size="sm" variant="ghost" onClick={() => navigate(`/agents/${a.id}`)}>
@@ -360,9 +372,10 @@ export default function AgentList() {
                       defaultChannel: defaultCh,
                       skills: pos?.defaultSkills || [],
                       deployMode: newDeployMode,
+                      ...(newDeployMode === 'always-on-ecs' && newTier ? { runtimeId: newTier } : {}),
                     } as any);
                   }
-                  setShowCreate(false); setNewName(''); setNewPos(''); setNewEmp(''); setNewDeployMode('serverless'); setCreateStep(0);
+                  setShowCreate(false); setNewName(''); setNewPos(''); setNewEmp(''); setNewDeployMode('serverless'); setNewTier(''); setCreateStep(0);
                 }}>Create Agent</Button>
               )}
             </div>
@@ -404,6 +417,58 @@ export default function AgentList() {
                 </button>
               </div>
             </div>
+            {/* Tier/Runtime selector — shown only for always-on mode */}
+            {newDeployMode === 'always-on-ecs' && (
+              <div className="rounded-xl bg-cyan/5 border border-cyan/20 p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <Zap size={14} className="text-cyan" />
+                  <span className="text-xs font-semibold text-text-primary">Fargate Configuration</span>
+                </div>
+                {runtimes.length > 0 ? (
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-text-secondary">Runtime Tier</label>
+                    <div className="grid grid-cols-2 gap-2">
+                      {runtimes.map((rt: any) => {
+                        const isSelected = newTier === rt.id;
+                        return (
+                          <button
+                            key={rt.id}
+                            onClick={() => setNewTier(rt.id)}
+                            className={`rounded-lg border p-2.5 text-left transition-all ${isSelected ? 'border-primary ring-2 ring-primary/30 bg-primary/5' : 'border-dark-border/40 hover:border-dark-border'}`}
+                          >
+                            <div className="flex items-center justify-between">
+                              <span className="text-xs font-semibold">{rt.name || rt.id}</span>
+                              {isSelected ? (
+                                <div className="flex h-4 w-4 items-center justify-center rounded-full bg-primary"><Check size={10} className="text-white" /></div>
+                              ) : (
+                                <div className="h-4 w-4 rounded-full border border-dark-border" />
+                              )}
+                            </div>
+                            <p className="text-[10px] text-text-muted mt-1">
+                              {rt.model || 'Default model'}
+                              {rt.guardrailId ? ` · Guardrail` : ' · No guardrail'}
+                            </p>
+                            <p className="text-[10px] text-text-muted">
+                              v{rt.version || '1'} · {rt.id?.slice(-8)}
+                            </p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {newPos && (posRuntimeMap as any)?.map?.[newPos] && (
+                      <p className="text-[10px] text-info">
+                        Position "{POSITIONS.find(p => p.id === newPos)?.name}" is mapped to runtime: {(posRuntimeMap as any).map[newPos]}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="text-center py-3">
+                    <p className="text-xs text-text-muted">No runtimes configured yet.</p>
+                    <p className="text-[10px] text-text-muted mt-1">Go to Security Center → Agent Runtimes to create runtime tiers first.</p>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
         {createStep === 1 && (
@@ -439,6 +504,9 @@ export default function AgentList() {
               <div><p className="text-xs text-text-muted">Employee</p><p className="text-sm font-medium">{EMPLOYEES.find(e => e.id === newEmp)?.name || '(not selected)'}</p></div>
               <div><p className="text-xs text-text-muted">Default Channel</p><p className="text-sm font-medium">{POSITIONS.find(p => p.id === newPos)?.defaultChannel || 'discord'}</p></div>
               <div><p className="text-xs text-text-muted">Deployment</p><p className="text-sm font-medium">{newDeployMode === 'always-on-ecs' ? '⚡ Always-on (Fargate)' : 'Serverless (AgentCore)'}</p></div>
+              {newDeployMode === 'always-on-ecs' && newTier && (
+                <div><p className="text-xs text-text-muted">Runtime Tier</p><p className="text-sm font-medium">{runtimes.find((r:any) => r.id === newTier)?.name || newTier}</p></div>
+              )}
             </div>
           </div>
         )}

--- a/enterprise/admin-console/src/pages/AuditLog.tsx
+++ b/enterprise/admin-console/src/pages/AuditLog.tsx
@@ -16,6 +16,10 @@ const eventTypeOptions = [
   { label: 'Approval Decision', value: 'approval_decision' },
   { label: 'Session Start', value: 'session_start' },
   { label: 'Session End', value: 'session_end' },
+  { label: 'Always-On Enabled', value: 'always_on_enabled' },
+  { label: 'Always-On Disabled', value: 'always_on_disabled' },
+  { label: 'IM Channel Connected', value: 'im_channel_connected' },
+  { label: 'IM Channel Disconnected', value: 'im_channel_disconnected' },
 ];
 
 const badgeColor = (type: string): 'success' | 'danger' | 'warning' | 'info' | 'default' => {
@@ -25,6 +29,10 @@ const badgeColor = (type: string): 'success' | 'danger' | 'warning' | 'info' | '
     case 'config_change': return 'warning';
     case 'approval_decision': return 'info';
     case 'tool_execution': return 'success';
+    case 'always_on_enabled': return 'info';
+    case 'always_on_disabled': return 'warning';
+    case 'im_channel_connected': return 'success';
+    case 'im_channel_disconnected': return 'danger';
     default: return 'default';
   }
 };

--- a/enterprise/admin-console/src/pages/Dashboard.tsx
+++ b/enterprise/admin-console/src/pages/Dashboard.tsx
@@ -38,16 +38,11 @@ const donutOptsBase: Omit<ApexOptions, 'labels' | 'plotOptions'> = {
   tooltip: { theme: 'dark' },
 };
 
-const barChartOpts: ApexOptions = {
+const barChartOptsBase: Omit<ApexOptions, 'xaxis'> = {
   chart: { type: 'bar', toolbar: { show: false }, background: 'transparent' },
   colors: ['#6366f1'],
   plotOptions: { bar: { borderRadius: 4, columnWidth: '50%' } },
   grid: { borderColor: '#2e3039', strokeDashArray: 4 },
-  xaxis: {
-    categories: ['Telegram', 'WhatsApp', 'Slack', 'Discord', 'Feishu', 'DingTalk'],
-    labels: { style: { colors: '#64748b', fontSize: '12px' } },
-    axisBorder: { show: false }, axisTicks: { show: false },
-  },
   yaxis: { labels: { style: { colors: '#64748b', fontSize: '12px' } } },
   tooltip: { theme: 'dark' },
   dataLabels: { enabled: false },
@@ -74,13 +69,14 @@ export default function Dashboard() {
   const pendingApprovals = approvalsData?.pending?.length || 0;
   const activeAlerts = alertRules.filter(a => a.status === 'warning').length;
   const topDepts = DEPARTMENTS.filter(d => !d.parentId);
-  const qualityAgents = AGENTS.filter(a => a.qualityScore);
+  const qualityAgents = AGENTS.filter(a => a.qualityScore != null && a.qualityScore > 0);
   const avgQuality = qualityAgents.length > 0
     ? qualityAgents.reduce((s, a) => s + (a.qualityScore || 0), 0) / qualityAgents.length
     : null;
   const channelCounts: Record<string, number> = {};
   BINDINGS.forEach(b => { channelCounts[b.channel] = (channelCounts[b.channel] || 0) + 1; });
-  const channelSeries = ['telegram', 'whatsapp', 'slack', 'discord', 'feishu', 'dingtalk'].map(c => channelCounts[c] || 0);
+  const activeChannels = Object.keys(channelCounts).sort();
+  const channelSeries = activeChannels.map(c => channelCounts[c] || 0);
   const agentsByPosition = POSITIONS.map(p => AGENTS.filter(a => a.positionId === p.id).length);
 
   // Setup checklist: first-time admin guidance
@@ -271,7 +267,7 @@ export default function Dashboard() {
                     <div>
                       <p className="text-sm font-medium text-text-primary">{a.name}</p>
                       <p className="text-xs text-text-muted">
-                        {a.channels.map(c => CHANNEL_LABELS[c as ChannelType]).join(', ')}
+                        {(a.channels || []).map(c => CHANNEL_LABELS[c as ChannelType]).join(', ') || 'No channels'}
                       </p>
                     </div>
                   </div>
@@ -293,7 +289,7 @@ export default function Dashboard() {
             <h3 className="text-lg font-semibold text-text-primary">Channel Distribution</h3>
             <p className="text-sm text-text-secondary">Bindings per messaging platform</p>
           </div>
-          <Chart options={barChartOpts} series={[{ name: 'Bindings', data: channelSeries }]} type="bar" height={260} />
+          <Chart options={{...barChartOptsBase, xaxis: { categories: activeChannels.map(c => CHANNEL_LABELS[c as ChannelType] || c), labels: { style: { colors: '#64748b', fontSize: '12px' } }, axisBorder: { show: false }, axisTicks: { show: false } }}} series={[{ name: 'Bindings', data: channelSeries }]} type="bar" height={260} />
         </Card>
 
         <Card>
@@ -322,7 +318,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center justify-between rounded-lg bg-dark-bg/50 px-3 py-2">
                   <span className="text-sm text-text-secondary">Agent Coverage</span>
-                  <span className="text-sm font-medium text-success">{Math.round(EMPLOYEES.filter(e => e.agentId).length / EMPLOYEES.length * 100)}%</span>
+                  <span className="text-sm font-medium text-success">{EMPLOYEES.length > 0 ? Math.round(EMPLOYEES.filter(e => e.agentId).length / EMPLOYEES.length * 100) : 0}%</span>
                 </div>
                 <div className="flex items-center justify-between rounded-lg bg-dark-bg/50 px-3 py-2">
                   <span className="text-sm text-text-secondary">Active Channels</span>

--- a/enterprise/admin-console/src/pages/Monitor/index.tsx
+++ b/enterprise/admin-console/src/pages/Monitor/index.tsx
@@ -46,6 +46,8 @@ export default function Monitor() {
   const actionItems = actionItemsData?.items || [];
   const agentActivity = agentActivityData?.agents || [];
   const activeAgents = agentActivity.filter((a: any) => a.status === 'active').length || AGENTS.filter(a => a.status === 'active').length;
+  const alwaysOnAgents = AGENTS.filter(a => a.deployMode === 'always-on-ecs');
+  const agentDeployMode = (agentId: string) => AGENTS.find(a => a.id === agentId)?.deployMode;
   const totalTurns = sessions.reduce((s, sess) => s + sess.turns, 0);
   const avgQuality = AGENTS.filter(a => a.qualityScore).length > 0
     ? AGENTS.filter(a => a.qualityScore).reduce((s, a) => s + (a.qualityScore || 0), 0) / AGENTS.filter(a => a.qualityScore).length
@@ -101,13 +103,14 @@ export default function Monitor() {
       </div>
 
       {/* System Health Bar */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 mb-6">
         {(() => {
           const sysStatus = systemStatusData || {};
           const services = [
             { label: 'Admin Console', status: (sysStatus as any)?.['admin-console'] || 'healthy', detail: 'Port 8099' },
             { label: 'Tenant Router', status: (sysStatus as any)?.['tenant-router'] || 'healthy', detail: 'Agent orchestration' },
             { label: 'Bedrock API', status: (sysStatus as any)?.bedrock || 'connected', detail: `${sys.bedrockLatencyMs || '—'}ms latency` },
+            { label: 'Fargate Agents', status: alwaysOnAgents.length > 0 ? 'healthy' : 'idle', detail: `${alwaysOnAgents.length} always-on` },
           ];
           return services.map(svc => (
             <div key={svc.label} className="rounded-lg border border-dark-border bg-dark-card px-4 py-3 flex items-center justify-between">
@@ -176,6 +179,12 @@ export default function Monitor() {
                   { key: 'arrow', label: '', render: () => <span className="text-text-muted">↔</span>, width: '40px' },
                   { key: 'agent', label: 'Agent', render: (s: typeof sessions[0]) => <button onClick={(e) => { e.stopPropagation(); navigate(`/agents/${s.agentId}`); }} className="font-medium text-primary-light hover:underline">{s.agentName}</button> },
                   { key: 'channel', label: 'Channel', render: (s: typeof sessions[0]) => <Badge color="info">{CHANNEL_LABELS[s.channel as ChannelType]}</Badge> },
+                  { key: 'mode', label: 'Mode', render: (s: typeof sessions[0]) => {
+                    const mode = agentDeployMode(s.agentId);
+                    return mode === 'always-on-ecs'
+                      ? <Badge color="success"><Zap size={10} className="inline mr-0.5" />Fargate</Badge>
+                      : <Badge color="default">Serverless</Badge>;
+                  }},
                   { key: 'duration', label: 'Duration', render: (s: typeof sessions[0]) => <span className="text-text-muted">{elapsed(s.startedAt)}</span> },
                   { key: 'turns', label: 'Turns', render: (s: typeof sessions[0]) => s.turns },
                   { key: 'lastMsg', label: 'Latest Message', render: (s: typeof sessions[0]) => <span className="text-xs text-text-muted truncate block max-w-[200px]">{s.lastMessage}</span> },
@@ -264,6 +273,7 @@ export default function Monitor() {
                       <p className="text-sm font-medium text-text-primary">{agent.agentName || agent.name}</p>
                       <p className="text-xs text-text-muted">{agent.employeeName} · {agent.positionName}</p>
                     </div>
+                    {(() => { const m = agentDeployMode(agent.agentId || agent.id); return m === 'always-on-ecs' ? <Badge color="success"><Zap size={10} className="inline mr-0.5" />Fargate</Badge> : null; })()}
                     <Badge color={agent.status === 'active' ? 'success' : agent.status === 'idle' ? 'warning' : 'default'}>{agent.status}</Badge>
                     {agent.lastInvocationAt && (
                       <span className="text-xs text-text-muted shrink-0">
@@ -313,6 +323,7 @@ export default function Monitor() {
                   <thead>
                     <tr className="border-b border-dark-border text-left">
                       <th className="pb-3 text-xs font-medium text-text-muted uppercase tracking-wider">Agent</th>
+                      <th className="pb-3 text-xs font-medium text-text-muted uppercase tracking-wider">Mode</th>
                       <th className="pb-3 text-xs font-medium text-text-muted uppercase tracking-wider">Status</th>
                       <th className="pb-3 text-xs font-medium text-text-muted uppercase tracking-wider">Quality</th>
                       <th className="pb-3 text-xs font-medium text-text-muted uppercase tracking-wider">Requests</th>
@@ -330,6 +341,9 @@ export default function Monitor() {
                             <p className="font-medium text-text-primary">{a.agentName}</p>
                             <p className="text-xs text-text-muted">{a.employeeName} · {a.positionName}</p>
                           </div>
+                        </td>
+                        <td className="py-3">
+                          {(() => { const m = agentDeployMode(a.agentId); return m === 'always-on-ecs' ? <Badge color="success"><Zap size={10} className="inline mr-0.5" />Fargate</Badge> : <Badge color="default">Serverless</Badge>; })()}
                         </td>
                         <td className="py-3"><StatusDot status={a.status} /></td>
                         <td className="py-3">

--- a/enterprise/admin-console/src/pages/Organization/Employees.tsx
+++ b/enterprise/admin-console/src/pages/Organization/Employees.tsx
@@ -437,6 +437,24 @@ export default function Employees() {
       }>
         <div className="space-y-3">
           <p className="text-sm text-text-primary">Delete employee <strong>{deletingEmp?.name}</strong>?</p>
+          {/* Always-On cleanup warning */}
+          {(() => {
+            const empAgent = AGENTS.find(a => a.employeeId === deletingEmp?.id);
+            const isAlwaysOn = empAgent?.deployMode === 'always-on-ecs';
+            return isAlwaysOn ? (
+              <div className="rounded-lg bg-warning/10 border border-warning/30 px-3 py-2.5 text-xs space-y-1">
+                <p className="font-semibold text-warning">Always-On agent will be cleaned up:</p>
+                <ul className="list-disc list-inside text-text-secondary space-y-0.5">
+                  <li>Stop & delete ECS Fargate service</li>
+                  <li>Delete EFS Access Point & workspace files</li>
+                  <li>Remove IM credentials (DynamoDB)</li>
+                  <li>Deregister SSM endpoint</li>
+                  <li>Delete S3 serverless workspace</li>
+                  <li>Remove all session, conversation, and usage records</li>
+                </ul>
+              </div>
+            ) : null;
+          })()}
           {deleteError && (
             <div className="flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2.5">
               <AlertTriangle size={16} className="text-danger mt-0.5 shrink-0" />

--- a/enterprise/admin-console/src/pages/SecurityCenter.tsx
+++ b/enterprise/admin-console/src/pages/SecurityCenter.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import {
   Shield, Cpu, Zap, Clock, Edit3, Save, X, Plus, ChevronRight,
   Package, Key, Network, Globe2, CheckCircle, AlertTriangle,
-  FileText, Wrench, RefreshCw, ExternalLink, Lock, Unlock,
+  FileText, Wrench, RefreshCw, ExternalLink, Lock, Unlock, Bot, Check,
 } from 'lucide-react';
 import { Card, Badge, Button, PageHeader, Tabs, Modal } from '../components/ui';
 import {
@@ -14,9 +14,10 @@ import {
   useModelConfig, useUpdateModelConfig, useUpdateFallbackModel,
   useSetPositionModel, useRemovePositionModel,
   usePositionRuntimeMap, useSetPositionRuntime, useDeletePositionRuntime,
-  useGuardrails, useServiceStatus, useFargateOverview,
+  useGuardrails, useServiceStatus, useFargateOverview, useEmployees, useEnableAlwaysOn,
 } from '../hooks/useApi';
 import { Select } from '../components/ui';
+import { api } from '../api/client';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ function RuntimeEditModal({ rt, models, onClose, awsRegion = 'us-east-1' }: { rt
     ...iamRoles.filter(r => r.relevant).map(r => ({ label: `${r.name} ★`, value: r.arn })),
     ...iamRoles.filter(r => !r.relevant).map(r => ({ label: r.name, value: r.arn })),
   ];
-  const sgOptions = securityGroups.map(sg => ({ label: `${sg.name} (${sg.id}) — ${sg.description.slice(0,40)}`, value: sg.id }));
+  const sgOptions = securityGroups.map(sg => ({ label: `${sg.name} (${sg.id}) — ${(sg.description || '').slice(0,40)}`, value: sg.id }));
   const subnetOptions = subnets.map(s => ({ label: `${s.id} — ${s.az} ${s.cidr}`, value: s.id }));
 
   const toggleSg = (id: string) => setSecurityGroupIds(s => s.includes(id) ? s.filter(x => x !== id) : [...s, id]);
@@ -1215,76 +1216,323 @@ export default function SecurityCenter() {
 
 function FargateOverviewPanel() {
   const { data, isLoading } = useFargateOverview() as { data: any; isLoading: boolean };
+  const { data: runtimesData } = useSecurityRuntimes() as { data: any };
+  const { data: runtimeMap } = usePositionRuntimeMap() as { data: any };
+  const { data: employeesData = [] } = useEmployees();
+  const { data: positionsData = [] } = usePositions();
   const agents = data?.alwaysOnAgents || [];
+  const runtimes = runtimesData?.runtimes || [];
+  const [showCreate, setShowCreate] = useState(false);
+  const [createEmp, setCreateEmp] = useState('');
+  const [createRuntime, setCreateRuntime] = useState('');
+  const [editingRuntime, setEditingRuntime] = useState<any>(null);
+  const [showNewTemplate, setShowNewTemplate] = useState(false);
+  const createRuntime2 = useCreateRuntime();
+  const enableAO = useEnableAlwaysOn();
 
   const tierColors: Record<string, string> = {
     standard: 'info', restricted: 'warning', engineering: 'success', executive: 'primary',
   };
 
+  const unassignedEmps = employeesData.filter((e: any) => e.agentId && !agents.find((a: any) => a.employeeId === e.id));
+
+  const handleCreate = () => {
+    if (createEmp && createRuntime) {
+      enableAO.mutate({ empId: createEmp, enable: true, runtimeId: createRuntime } as any);
+      setShowCreate(false);
+      setCreateEmp('');
+      setCreateRuntime('');
+    }
+  };
+
+  const { data: mc } = useModelConfig() as { data: any };
+  const models = mc?.availableModels || [];
+  const findModelName = (id: string) => models.find((m: any) => m.modelId === id)?.modelName || id?.split('/').pop()?.split(':')[0] || '—';
+
   return (
     <div className="space-y-6">
-      <Card>
-        <div className="flex items-center justify-between mb-4">
+      {/* Info banner + create button */}
+      <div className="flex items-start justify-between">
+        <div className="rounded-xl bg-cyan/5 border border-cyan/20 px-4 py-3 flex items-start gap-3 flex-1 mr-4">
+          <Zap size={16} className="text-cyan mt-0.5 shrink-0" />
           <div>
-            <h3 className="text-lg font-semibold text-text-primary">Always-On Agents (Fargate)</h3>
-            <p className="text-sm text-text-muted mt-1">
-              Per-employee Fargate containers with dedicated Gateway, IM direct connection, and HEARTBEAT support
+            <p className="text-sm font-semibold text-text-primary">Each runtime can serve as a Fargate tier. Assign employees below to give them dedicated always-on containers.</p>
+            <p className="text-xs text-text-muted mt-0.5">
+              Fargate agents use the same Docker image and runtime config as Agent Runtimes, but run 24/7 with EFS persistence,
+              instant response, and HEARTBEAT support. ~$7-16/month per container.
             </p>
           </div>
-          <Badge color="primary">{agents.length} active</Badge>
         </div>
+        <div className="flex flex-col gap-2">
+          <Button variant="primary" onClick={() => setShowNewTemplate(true)}>
+            <Plus size={16} /> New Fargate Template
+          </Button>
+          <Button variant="default" onClick={() => setShowCreate(true)} disabled={runtimes.length === 0}>
+            <Plus size={16} /> Assign to Employee
+          </Button>
+        </div>
+      </div>
 
-        {isLoading ? (
-          <div className="flex justify-center py-8 text-text-muted">Loading...</div>
-        ) : agents.length === 0 ? (
+      {/* P1-C: Cost summary + Bulk operations */}
+      {agents.length > 0 && (
+        <div className="flex items-center justify-between rounded-xl bg-dark-card border border-dark-border px-4 py-3">
+          <div className="flex items-center gap-6">
+            <div>
+              <p className="text-[10px] text-text-muted uppercase">Running</p>
+              <p className="text-lg font-bold text-success">{agents.filter((a: any) => a.status === 'running').length}</p>
+            </div>
+            <div>
+              <p className="text-[10px] text-text-muted uppercase">Stopped</p>
+              <p className="text-lg font-bold text-text-muted">{agents.filter((a: any) => a.status !== 'running').length}</p>
+            </div>
+            <div>
+              <p className="text-[10px] text-text-muted uppercase">Est. Monthly Cost</p>
+              <p className="text-lg font-bold text-warning">
+                ~${agents.reduce((sum: number, a: any) => {
+                  if (a.status !== 'running') return sum;
+                  const isHighTier = a.tier === 'executive' || a.tier === 'engineering';
+                  return sum + (isHighTier ? 16.34 : 7.42);
+                }, 0).toFixed(2)}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="default" size="sm" onClick={async () => {
+              for (const a of agents.filter((ag: any) => ag.status === 'running')) {
+                await enableAO.mutateAsync({ empId: a.employeeId, enable: false } as any).catch(() => {});
+              }
+              window.location.reload();
+            }}>Stop All</Button>
+            <Button variant="default" size="sm" onClick={async () => {
+              for (const a of agents) {
+                await api.post(`/agents/${a.employeeId}/always-on/restart`, {}).catch(() => {});
+              }
+              window.location.reload();
+            }}><RefreshCw size={12} /> Restart All</Button>
+          </div>
+        </div>
+      )}
+
+      {/* Runtime Tier Cards — same style as Agent Runtimes */}
+      {isLoading ? (
+        <div className="flex justify-center py-8 text-text-muted">Loading...</div>
+      ) : runtimes.length === 0 ? (
+        <Card>
           <div className="rounded-lg bg-dark-bg p-6 text-center">
-            <p className="text-text-muted">No always-on agents configured</p>
-            <p className="text-xs text-text-muted mt-1">
-              Enable always-on in Agent Factory → employee detail → Enable Always-On
+            <Bot size={28} className="mx-auto mb-2 opacity-30" />
+            <p className="text-text-muted">No runtimes configured</p>
+            <p className="text-xs text-text-muted mt-1">Create runtimes in the Agent Runtimes tab first, then assign employees here.</p>
+          </div>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {runtimes.map((rt: any) => {
+            const isExec = rt.name?.toLowerCase().includes('exec');
+            const imageTag = rt.containerUri?.split('/').pop() || 'unknown';
+            const roleName = rt.roleArn?.split('/').pop() || '—';
+            const modelName = findModelName(rt.model);
+            const assignedAgents = agents.filter((a: any) => a.tier === rt.name || a.runtimeId === rt.id);
+            const assignedPositions = Object.entries((runtimeMap as any)?.map || {})
+              .filter(([_, rid]) => rid === rt.id)
+              .map(([posId]) => positionsData.find((p: any) => p.id === posId))
+              .filter(Boolean);
+
+            return (
+              <Card key={rt.id} className={isExec ? 'border-warning/30' : ''}>
+                {/* Header */}
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex items-center gap-3">
+                    <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${isExec ? 'bg-warning/10' : 'bg-cyan/10'}`}>
+                      <Zap size={20} className={isExec ? 'text-warning' : 'text-cyan'} />
+                    </div>
+                    <div>
+                      <h3 className="text-sm font-semibold text-text-primary">{rt.name}</h3>
+                      <p className="text-xs text-text-muted">v{rt.version || '1'} · {rt.id?.slice(-8)} · Fargate Tier</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge color={rt.status === 'READY' ? 'success' : 'warning'} dot>{rt.status || 'UNKNOWN'}</Badge>
+                    <Badge color="info">{assignedAgents.length} agent{assignedAgents.length !== 1 ? 's' : ''}</Badge>
+                    <Button size="sm" variant="primary" onClick={() => setEditingRuntime(rt)}>
+                      <Edit3 size={12} /> Configure
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Config rows — matching RuntimeCard style */}
+                <div className="space-y-2 mb-4">
+                  {[
+                    { label: 'Container Image', value: imageTag },
+                    { label: 'Default Model', value: modelName },
+                    { label: 'IAM Role', value: roleName,
+                      extra: <Badge color={isExec ? 'danger' : 'info'}>{isExec ? 'Full Access' : 'Scoped'}</Badge> },
+                    { label: 'Storage', value: 'EFS', extra: <Badge color="success">Persistent</Badge> },
+                    { label: 'Guardrail (L5)',
+                      value: rt.guardrailId ? `${rt.guardrailId} v${rt.guardrailVersion || '1'}` : '—',
+                      extra: rt.guardrailId
+                        ? <Badge color="warning"><Shield size={10} className="mr-0.5" />Active</Badge>
+                        : <Badge color="default">None</Badge> },
+                  ].map(row => (
+                    <div key={row.label} className="flex items-center justify-between rounded-xl bg-surface-dim px-3 py-2">
+                      <span className="text-xs text-text-muted">{row.label}</span>
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-xs font-mono text-text-secondary">{row.value}</span>
+                        {(row as any).extra}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Lifecycle stats */}
+                <div className="border-t border-dark-border/30 pt-3 grid grid-cols-2 gap-2 mb-4">
+                  <div className="rounded-xl bg-surface-dim px-3 py-2.5">
+                    <p className="text-[10px] text-text-muted">Mode</p>
+                    <p className="text-base font-bold text-text-primary">24/7</p>
+                    <p className="text-[10px] text-text-muted">Always running</p>
+                  </div>
+                  <div className="rounded-xl bg-surface-dim px-3 py-2.5">
+                    <p className="text-[10px] text-text-muted">Est. cost</p>
+                    <p className="text-base font-bold text-text-primary">~${isExec ? '16' : '7'}/mo</p>
+                    <p className="text-[10px] text-text-muted">Per container</p>
+                  </div>
+                </div>
+
+                {/* Assigned Positions */}
+                {assignedPositions.length > 0 && (
+                  <div className="mb-3">
+                    <p className="text-[10px] font-medium text-text-muted uppercase tracking-wider mb-1.5">Mapped Positions ({assignedPositions.length})</p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {assignedPositions.map((p: any) => <Badge key={p.id} color="primary">{p.name}</Badge>)}
+                    </div>
+                  </div>
+                )}
+
+                {/* Assigned Employees */}
+                <div className="border-t border-dark-border/30 pt-3">
+                  <p className="text-[10px] font-medium text-text-muted uppercase tracking-wider mb-1.5">
+                    Assigned Employees ({assignedAgents.length})
+                  </p>
+                  {assignedAgents.length === 0 ? (
+                    <p className="text-xs text-text-muted py-2">No employees assigned to this tier yet.</p>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {assignedAgents.map((a: any) => (
+                        <div key={a.employeeId} className="flex items-center justify-between rounded-lg bg-dark-bg/50 px-3 py-2">
+                          <div className="flex items-center gap-2">
+                            <div className={`w-2 h-2 rounded-full ${a.status === 'running' ? 'bg-success animate-pulse' : 'bg-warning'}`} />
+                            <div>
+                              <span className="text-xs font-medium text-text-primary">{a.employeeName}</span>
+                              <span className="text-xs text-text-muted ml-1.5">{a.positionName}</span>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {(a.imChannels || []).map((ch: string) => <Badge key={ch} color="info">{ch}</Badge>)}
+                            <Badge color={a.status === 'running' ? 'success' : 'danger'}>{a.status}</Badge>
+                            <Button variant="ghost" size="sm" className="text-danger"
+                              onClick={() => enableAO.mutate({ empId: a.employeeId, enable: false })}>
+                              Stop
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Create/Assign Modal */}
+      {showCreate && (
+        <Modal open={true} onClose={() => setShowCreate(false)} title="Assign Always-On Agent"
+          footer={
+            <div className="flex justify-end gap-3">
+              <Button variant="default" onClick={() => setShowCreate(false)}>Cancel</Button>
+              <Button variant="primary" onClick={handleCreate} disabled={!createEmp || !createRuntime}>
+                Create & Start
+              </Button>
+            </div>
+          }>
+          <div className="space-y-4">
+            <p className="text-xs text-text-muted">
+              This will create a dedicated Fargate container for the selected employee using the chosen runtime template.
+              The container starts immediately and runs 24/7 (~$7-16/month).
             </p>
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-dark-border">
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">Employee</th>
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">Position</th>
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">Tier</th>
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">Status</th>
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">IM Channels</th>
-                  <th className="text-left py-2 px-3 text-xs text-text-muted font-medium">Service</th>
-                </tr>
-              </thead>
-              <tbody>
-                {agents.map((a: any) => (
-                  <tr key={a.employeeId} className="border-b border-dark-border/50 hover:bg-dark-hover">
-                    <td className="py-2 px-3 font-medium">{a.employeeName}</td>
-                    <td className="py-2 px-3 text-text-secondary">{a.positionName}</td>
-                    <td className="py-2 px-3">
-                      <Badge color={(tierColors[a.tier] || 'default') as any}>{a.tier}</Badge>
-                    </td>
-                    <td className="py-2 px-3">
-                      <Badge color={a.status === 'starting' || a.status === 'running' ? 'success' : 'danger'}>
-                        {a.status}
-                      </Badge>
-                    </td>
-                    <td className="py-2 px-3">
-                      {(a.imChannels || []).length === 0
-                        ? <span className="text-text-muted">—</span>
-                        : (a.imChannels || []).map((ch: string) => (
-                            <Badge key={ch} color="info">{ch}</Badge>
-                          ))
-                      }
-                    </td>
-                    <td className="py-2 px-3 font-mono text-xs text-text-muted">{a.serviceName}</td>
-                  </tr>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-text-secondary">Employee</label>
+              <select value={createEmp} onChange={e => setCreateEmp(e.target.value)}
+                className="w-full rounded-xl border border-dark-border/60 bg-surface-dim px-4 py-2.5 text-sm text-text-primary focus:border-primary/60 focus:outline-none">
+                <option value="">Select employee...</option>
+                {unassignedEmps.map((e: any) => (
+                  <option key={e.id} value={e.id}>{e.name} — {e.positionName}</option>
                 ))}
-              </tbody>
-            </table>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-text-secondary">Runtime Template</label>
+              <div className="grid grid-cols-2 gap-2">
+                {runtimes.map((rt: any) => {
+                  const sel = createRuntime === rt.id;
+                  return (
+                    <button key={rt.id} onClick={() => setCreateRuntime(rt.id)}
+                      className={`rounded-lg border p-2.5 text-left transition-all ${sel ? 'border-primary ring-2 ring-primary/30 bg-primary/5' : 'border-dark-border/40 hover:border-dark-border'}`}>
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-semibold">{rt.name}</span>
+                        {sel ? (
+                          <div className="flex h-4 w-4 items-center justify-center rounded-full bg-primary"><Check size={10} className="text-white" /></div>
+                        ) : (
+                          <div className="h-4 w-4 rounded-full border border-dark-border" />
+                        )}
+                      </div>
+                      <p className="text-[10px] text-text-muted mt-1">{rt.model || 'Default model'}</p>
+                      <p className="text-[10px] text-text-muted">
+                        {rt.guardrailId ? 'Guardrail' : 'No guardrail'} · v{rt.version || '1'}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            {createEmp && createRuntime && (
+              <div className="rounded-xl bg-info/5 border border-info/20 p-3 text-xs text-info">
+                Will create a Fargate container for <strong>{unassignedEmps.find((e: any) => e.id === createEmp)?.name}</strong> using
+                runtime <strong>{runtimes.find((r: any) => r.id === createRuntime)?.name}</strong>.
+              </div>
+            )}
           </div>
-        )}
-      </Card>
+        </Modal>
+      )}
+
+      {/* Edit Runtime Modal — reuses RuntimeEditModal */}
+      {editingRuntime && (
+        <RuntimeEditModal rt={editingRuntime} models={models} onClose={() => setEditingRuntime(null)} />
+      )}
+
+      {/* New Fargate Template — creates a new runtime via same API */}
+      {showNewTemplate && (
+        <Modal open={true} onClose={() => setShowNewTemplate(false)} title="Create Fargate Template"
+          footer={
+            <div className="flex justify-end gap-3">
+              <Button variant="default" onClick={() => setShowNewTemplate(false)}>Cancel</Button>
+              <Button variant="primary" onClick={() => {
+                createRuntime2.mutate({} as any);
+                setShowNewTemplate(false);
+              }}>Create Template</Button>
+            </div>
+          }>
+          <div className="space-y-3">
+            <p className="text-xs text-text-muted">
+              This creates a new runtime template for Fargate agents. After creation, use "Configure" to set the model,
+              IAM role, security group, and guardrail. Then assign employees to start Fargate containers.
+            </p>
+            <div className="rounded-xl bg-info/5 border border-info/20 p-3 text-xs text-info">
+              Tip: Runtimes are shared between Agent Runtimes and Fargate tabs — any runtime can serve as a Fargate tier.
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/enterprise/admin-console/src/pages/Settings.tsx
+++ b/enterprise/admin-console/src/pages/Settings.tsx
@@ -191,6 +191,7 @@ function PlatformLogsTab() {
     { label: 'Admin Console (openclaw-admin)', value: 'openclaw-admin' },
     { label: 'Tenant Router', value: 'tenant-router' },
     { label: 'Bedrock H2 Proxy', value: 'bedrock-proxy-h2' },
+    { label: 'Fargate Containers (CloudWatch)', value: 'fargate-containers' },
   ];
 
   const handleRestart = async (svcName: string) => {
@@ -453,6 +454,7 @@ function SystemTab() {
           { name: 'Bedrock', status: svc.bedrock.status, details: [`Region: ${svc.bedrock.region}`, `Latency: ${svc.bedrock.latencyMs}ms`, svc.bedrock.vpcEndpoint ? 'VPC Endpoint' : 'Public endpoint'] },
           { name: 'DynamoDB', status: svc.dynamodb.status, details: [svc.dynamodb.table, `${svc.dynamodb.itemCount} items`] },
           { name: 'S3', status: svc.s3.status, details: [svc.s3.bucket] },
+          { name: 'ECS Fargate', status: (svc as any).ecs?.status || 'not configured', details: [(svc as any).ecs?.cluster || 'No cluster', `${(svc as any).ecs?.runningTasks || 0} running tasks`] },
         ].map(s => {
           const ok = ['running', 'healthy', 'connected', 'active'].includes(s.status);
           return (

--- a/enterprise/admin-console/src/pages/Usage.tsx
+++ b/enterprise/admin-console/src/pages/Usage.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import Chart from 'react-apexcharts';
 import type { ApexOptions } from 'apexcharts';
-import { DollarSign, TrendingUp, TrendingDown, Users, Bot, AlertTriangle, Download, Cpu, Plus, Edit3, Save, Wallet } from 'lucide-react';
+import { DollarSign, TrendingUp, TrendingDown, Users, Bot, AlertTriangle, Download, Cpu, Plus, Edit3, Save, Wallet, Zap } from 'lucide-react';
 import { Card, StatCard, Badge, Button, PageHeader, Table, Tabs, Select, Modal } from '../components/ui';
-import { useUsageSummary, useUsageByDepartment, useUsageByAgent, useUsageBudgets, useUsageTrend, useUsageByModel, useModelConfig, useUpdateModelConfig, useUpdateFallbackModel, usePositions, useAgentConfig, useKBAssignments, useUpdateBudgets } from '../hooks/useApi';
+import { useUsageSummary, useUsageByDepartment, useUsageByAgent, useUsageBudgets, useUsageTrend, useUsageByModel, useModelConfig, useUpdateModelConfig, useUpdateFallbackModel, usePositions, useAgentConfig, useKBAssignments, useUpdateBudgets, useAgents } from '../hooks/useApi';
 import { useAuth } from '../contexts/AuthContext';
 
 const costTrendOpts: ApexOptions = {
@@ -26,6 +26,8 @@ export default function Usage() {
   const { data: summary } = useUsageSummary();
   const { data: byDept = [] } = useUsageByDepartment();
   const { data: byAgent = [] } = useUsageByAgent();
+  const { data: AGENTS = [] } = useAgents();
+  const getAgentMode = (agentId: string) => AGENTS.find(a => a.id === agentId)?.deployMode;
   const { data: byModel = [] } = useUsageByModel();
   const { data: budgets = [] } = useUsageBudgets();
   const { data: trend = [] } = useUsageTrend();
@@ -125,12 +127,13 @@ export default function Usage() {
         }
       />
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-5 mb-6">
-        <StatCard title="Total Cost" value={`$${s.totalCost.toFixed(2)}`} subtitle={`${s.totalRequests} requests`} icon={<DollarSign size={22} />} color="success" />
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-6 mb-6">
+        <StatCard title="Bedrock Cost" value={`$${s.totalCost.toFixed(2)}`} subtitle={`${s.totalRequests} requests`} icon={<DollarSign size={22} />} color="success" />
+        <StatCard title="Fargate Cost" value={(() => { const aoCount = AGENTS.filter(a => a.deployMode === 'always-on-ecs').length; const est = aoCount * 12; return aoCount > 0 ? `~$${est}/mo` : '$0'; })()} subtitle={`${AGENTS.filter(a => a.deployMode === 'always-on-ecs').length} containers`} icon={<Zap size={22} />} color="cyan" />
         <StatCard title="Input Tokens" value={`${(s.totalInputTokens / 1000).toFixed(0)}k`} subtitle="Today" icon={<TrendingUp size={22} />} color="primary" />
         <StatCard title="Output Tokens" value={`${(s.totalOutputTokens / 1000).toFixed(0)}k`} subtitle="Today" icon={<TrendingDown size={22} />} color="info" />
-        <StatCard title="Active Tenants" value={s.tenantCount} subtitle="With agents" icon={<Users size={22} />} color="cyan" />
-        <StatCard title="Avg Cost/Request" value={s.totalRequests > 0 ? `$${(s.totalCost / s.totalRequests).toFixed(4)}` : '—'} subtitle="Per invocation" icon={<Bot size={22} />} color="warning" />
+        <StatCard title="Active Tenants" value={s.tenantCount} subtitle="With agents" icon={<Users size={22} />} color="warning" />
+        <StatCard title="Avg Cost/Req" value={s.totalRequests > 0 ? `$${(s.totalCost / s.totalRequests).toFixed(4)}` : '—'} subtitle="Per invocation" icon={<Bot size={22} />} color="info" />
       </div>
 
       {/* Cost trend chart */}
@@ -220,6 +223,12 @@ export default function Usage() {
                 { key: 'agent', label: 'Agent', render: (a: typeof byAgent[0]) => (
                   <div><p className="font-medium">{a.agentName}</p><p className="text-xs text-text-muted">{a.employeeName}</p></div>
                 )},
+                { key: 'mode', label: 'Mode', render: (a: typeof byAgent[0]) => {
+                  const mode = getAgentMode(a.agentId);
+                  return mode === 'always-on-ecs'
+                    ? <Badge color="success"><Zap size={10} className="inline mr-0.5" />Fargate</Badge>
+                    : <Badge color="default">Serverless</Badge>;
+                }},
                 { key: 'position', label: 'Position', render: (a: typeof byAgent[0]) => <Badge>{a.positionName}</Badge> },
                 { key: 'requests', label: 'Requests', render: (a: typeof byAgent[0]) => a.requests },
                 { key: 'input', label: 'Input', render: (a: typeof byAgent[0]) => `${(a.inputTokens / 1000).toFixed(1)}k` },

--- a/enterprise/admin-console/src/pages/Workspace/index.tsx
+++ b/enterprise/admin-console/src/pages/Workspace/index.tsx
@@ -126,9 +126,10 @@ export default function Workspace() {
     }
   }, [agents, selectedAgent, searchParams]);
 
-  const { data: wsTree, isLoading: treeLoading } = useWorkspaceTree(selectedAgent);
-
   const agent = agents.find(a => a.id === selectedAgent);
+  const wsAgentType = agent?.deployMode === 'always-on-ecs' ? 'always-on' as const : 'serverless' as const;
+  const { data: wsTree, isLoading: treeLoading } = useWorkspaceTree(selectedAgent, wsAgentType);
+
   const position = positions.find(p => p.id === agent?.positionId);
 
   // Build structured file list from workspace tree API
@@ -270,6 +271,11 @@ export default function Workspace() {
             )}
           </div>
           <div className="flex items-center gap-2 text-sm">
+            {agent?.deployMode === 'always-on-ecs' ? (
+              <Badge color="success">EFS · Persistent</Badge>
+            ) : (
+              <Badge color="info">S3 · Sync on session end</Badge>
+            )}
             <Badge>🔒 Global {globalSoul.length + globalSkills.length}</Badge>
             <ArrowRight size={14} className="text-text-muted" />
             <Badge color="primary">📋 {position?.name || '?'} {posSoul.length + posSkills.length}</Badge>
@@ -352,7 +358,7 @@ export default function Workspace() {
           <div className="lg:col-span-3 mb-2">
             <div className="flex items-center gap-3 rounded-xl bg-danger/10 border border-danger/30 px-4 py-3 text-sm">
               <AlertTriangle size={16} className="text-danger shrink-0" />
-              <span className="text-text-primary flex-1"><strong>Warning:</strong> Saving SOUL.md changes affects live agent behavior immediately. All new sessions will use the updated SOUL.</span>
+              <span className="text-text-primary flex-1"><strong>Warning:</strong> Saving SOUL.md changes affects live agent behavior immediately. {agent?.deployMode === 'always-on-ecs' ? 'The always-on Fargate container will apply changes within seconds via /admin/refresh.' : 'All new sessions will use the updated SOUL.'}</span>
               <Button size="sm" variant="danger" onClick={async () => {
                 setConfirmSoul(false);
                 setSaving(true);

--- a/enterprise/admin-console/src/pages/portal/BindIM.tsx
+++ b/enterprise/admin-console/src/pages/portal/BindIM.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { CheckCircle, Loader2, RefreshCw, Link2, ExternalLink, Clock, AlertCircle, UserPlus, Zap, Radio } from 'lucide-react';
-import { Card, Badge, Button } from '../../components/ui';
+import { CheckCircle, Loader2, RefreshCw, Link2, ExternalLink, Clock, AlertCircle, UserPlus, Zap, Radio, Copy, Key } from 'lucide-react';
+import { Card, Badge, Button, Modal } from '../../components/ui';
 import { api } from '../../api/client';
 import { IM_ICONS } from '../../components/IMIcons';
+import { usePortalAgent } from '../../contexts/PortalAgentContext';
 
 interface Channel {
   id: string;
@@ -269,6 +270,121 @@ function ChannelWizard({ channel, onDone, onCancel }: { channel: Channel; onDone
   );
 }
 
+// ── Credential fields per IM platform ──────────────────────────────────────
+const CREDENTIAL_FIELDS: Record<string, { label: string; key: string; placeholder: string; secret?: boolean }[]> = {
+  feishu:    [{ label: 'App ID', key: 'appId', placeholder: 'cli_xxxxxxxxxxxxxxxx' }, { label: 'App Secret', key: 'appSecret', placeholder: 'Enter app secret', secret: true }],
+  telegram:  [{ label: 'Bot Token', key: 'token', placeholder: '123456789:ABCdefGhIJKlmNoPQRsTUVwxYZ', secret: true }],
+  slack:     [{ label: 'Bot Token', key: 'botToken', placeholder: 'xoxb-...', secret: true }, { label: 'App Token', key: 'appToken', placeholder: 'xapp-...', secret: true }],
+  discord:   [{ label: 'Bot Token', key: 'token', placeholder: 'Enter Discord bot token', secret: true }],
+  dingtalk:  [{ label: 'App Key', key: 'appKey', placeholder: 'dingxxxxxxxx' }, { label: 'App Secret', key: 'appSecret', placeholder: 'Enter app secret', secret: true }],
+  teams:     [{ label: 'App ID', key: 'appId', placeholder: 'Enter Teams app ID' }, { label: 'App Secret', key: 'appSecret', placeholder: 'Enter secret', secret: true }],
+  googlechat:[{ label: 'Service Account JSON', key: 'serviceAccount', placeholder: 'Paste service account JSON', secret: true }],
+  whatsapp:  [{ label: 'Phone Number ID', key: 'phoneNumberId', placeholder: 'Enter phone number ID' }, { label: 'Access Token', key: 'accessToken', placeholder: 'Enter access token', secret: true }],
+  wechat:    [{ label: 'App ID', key: 'appId', placeholder: 'Enter WeChat app ID' }, { label: 'App Secret', key: 'appSecret', placeholder: 'Enter secret', secret: true }],
+};
+
+const PLATFORM_SETUP_GUIDE: Record<string, string[]> = {
+  feishu:   ['1. Go to open.feishu.cn → Create Enterprise App', '2. Enable "Bot" capability', '3. Set Event Subscription URL to the webhook URL below', '4. Submit for enterprise admin approval', '5. After approval, enter App ID and App Secret below'],
+  telegram: ['1. Open Telegram → message @BotFather', '2. Send /newbot → follow instructions', '3. Copy the bot token'],
+  slack:    ['1. Go to api.slack.com/apps → Create New App', '2. Add Bot Token Scopes (chat:write, channels:history)', '3. Install to workspace → copy Bot Token & App Token'],
+  discord:  ['1. Go to discord.com/developers → New Application', '2. Create a Bot → copy token', '3. Invite bot to your server with message permissions'],
+};
+
+function AlwaysOnChannelConnect({ channel, endpoint, onDone, onCancel }: { channel: Channel; endpoint: string; onDone: () => void; onCancel: () => void }) {
+  const fields = CREDENTIAL_FIELDS[channel.id] || [{ label: 'Token', key: 'token', placeholder: 'Enter token', secret: true }];
+  const guide = PLATFORM_SETUP_GUIDE[channel.id];
+  const [creds, setCreds] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const webhookUrl = endpoint ? `${endpoint}/webhook/${channel.id}` : '';
+
+  const handleSubmit = async () => {
+    const missing = fields.filter(f => !creds[f.key]?.trim());
+    if (missing.length > 0) { setError(`Please fill in: ${missing.map(f => f.label).join(', ')}`); return; }
+    setSubmitting(true); setError('');
+    try {
+      await api.post('/portal/agent/channels/add', { channel: channel.id, credentials: creds });
+      setDone(true);
+      setTimeout(onDone, 2000);
+    } catch (e: any) {
+      setError(e?.response?.data?.detail || e?.message || 'Connection failed');
+    } finally { setSubmitting(false); }
+  };
+
+  if (done) return (
+    <div className="flex flex-col items-center py-8 gap-3 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-success/10">
+        <CheckCircle size={36} className="text-success" />
+      </div>
+      <h3 className="text-base font-semibold text-text-primary">Connected!</h3>
+      <p className="text-sm text-text-muted">Your {channel.label} is now linked to your Always-On Agent.</p>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl bg-surface-dim p-4 text-center">
+        <div className="flex justify-center mb-2">{IM_ICONS[channel.id] ? (() => { const Icon = IM_ICONS[channel.id]; return <Icon size={48} />; })() : null}</div>
+        <h3 className="text-base font-semibold text-text-primary">Connect {channel.label}</h3>
+        <p className="text-xs text-text-muted mt-1">Direct connection to your Always-On agent</p>
+      </div>
+
+      {/* Setup guide */}
+      {guide && (
+        <div className="rounded-xl bg-info/5 border border-info/20 p-3 space-y-1">
+          <p className="text-xs font-semibold text-info">Setup Guide</p>
+          {guide.map((step, i) => (
+            <p key={i} className="text-xs text-text-secondary">{step}</p>
+          ))}
+        </div>
+      )}
+
+      {/* Webhook URL (if endpoint available) */}
+      {webhookUrl && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-text-secondary">Webhook URL (copy to {channel.label} platform)</label>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs font-mono text-primary-light bg-primary/10 px-3 py-2.5 rounded-lg truncate">{webhookUrl}</code>
+            <button onClick={() => { navigator.clipboard?.writeText(webhookUrl); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
+              className="flex-shrink-0 px-2.5 py-2.5 rounded-lg bg-dark-hover text-text-muted hover:text-text-primary text-xs border border-dark-border/40 transition-colors">
+              {copied ? <CheckCircle size={14} className="text-success" /> : <Copy size={14} />}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Credential fields */}
+      {fields.map(f => (
+        <div key={f.key}>
+          <label className="mb-1 block text-xs font-medium text-text-secondary">{f.label}</label>
+          <input
+            type={f.secret ? 'password' : 'text'}
+            value={creds[f.key] || ''}
+            onChange={e => setCreds(prev => ({ ...prev, [f.key]: e.target.value }))}
+            placeholder={f.placeholder}
+            className="w-full rounded-xl border border-dark-border/60 bg-surface-dim px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-primary/60 focus:outline-none font-mono"
+          />
+        </div>
+      ))}
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2">
+          <AlertCircle size={14} className="text-danger mt-0.5 shrink-0" />
+          <p className="text-xs text-danger">{error}</p>
+        </div>
+      )}
+
+      <Button variant="primary" className="w-full" onClick={handleSubmit} disabled={submitting}>
+        {submitting ? <><Loader2 size={14} className="animate-spin" /> Connecting...</> : <><Key size={14} /> Connect & Verify</>}
+      </Button>
+      <Button variant="ghost" className="w-full" onClick={onCancel}>Back</Button>
+    </div>
+  );
+}
+
 function GatewayConsoleButton() {
   const [loading, setLoading] = useState(false);
   const [countdown, setCountdown] = useState(0);
@@ -349,6 +465,11 @@ export default function BindIM() {
   const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null);
   const [channelInfo, setChannelInfo] = useState<any>(null);
   const [adminConfigured, setAdminConfigured] = useState<string[]>([]);
+  const { agentType: agentMode, hasAlwaysOn, alwaysOnInfo: aoCtx } = usePortalAgent();
+  const [alwaysOnEndpoint, setAlwaysOnEndpoint] = useState('');
+  const [alwaysOnAllowed, setAlwaysOnAllowed] = useState<string[]>([]);
+  const [selectedAOChannel, setSelectedAOChannel] = useState<Channel | null>(null);
+  const [aoConnected, setAoConnected] = useState<string[]>([]);
   const connectedRef = useRef<string[]>([]);
 
   // Fetch which channels admin has configured via OpenClaw Gateway
@@ -356,6 +477,14 @@ export default function BindIM() {
     api.get<{ configured: string[] }>('/portal/im-channel-status')
       .then(d => setAdminConfigured(d.configured || []))
       .catch(() => {});
+    // Fetch always-on details for endpoint and allowed platforms
+    if (hasAlwaysOn) {
+      api.get<any>('/portal/my-agents').then(d => {
+        setAlwaysOnEndpoint(d?.alwaysOn?.endpoint || aoCtx?.endpoint || '');
+        setAlwaysOnAllowed(d?.allowedIMPlatforms || []);
+        setAoConnected((d?.alwaysOn?.imChannels || []).map((c: any) => c.channel || c));
+      }).catch(() => {});
+    }
   }, []);
 
   const fetchChannels = useCallback(() => {
@@ -396,6 +525,19 @@ export default function BindIM() {
     setConfirmDisconnect(null);
   }, []);
 
+  // Always-On channel credential input wizard
+  if (selectedAOChannel) return (
+    <div className="max-w-sm mx-auto p-6">
+      <AlwaysOnChannelConnect
+        channel={selectedAOChannel}
+        endpoint={alwaysOnEndpoint}
+        onDone={() => { setAoConnected(prev => [...prev, selectedAOChannel.id]); setSelectedAOChannel(null); }}
+        onCancel={() => setSelectedAOChannel(null)}
+      />
+    </div>
+  );
+
+  // Serverless channel pairing wizard
   if (selected) return (
     <div className="max-w-sm mx-auto p-6">
       <ChannelWizard
@@ -406,9 +548,8 @@ export default function BindIM() {
     </div>
   );
 
-  const deployMode = channelInfo?.deployMode || 'serverless';
-  const pairingMode = channelInfo?.pairingMode || 'shared-gateway';
   const instructions = channelInfo?.pairingInstructions || {};
+  const effectiveMode = agentMode;
 
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6">
@@ -419,33 +560,78 @@ export default function BindIM() {
         </p>
       </div>
 
-      {/* Mode Banner */}
-      <div className={`rounded-xl border px-4 py-3 flex items-start gap-3 ${
-        deployMode === 'always-on-ecs'
-          ? 'bg-primary/5 border-primary/20'
-          : 'bg-surface-dim border-dark-border/40'
-      }`}>
-        {deployMode === 'always-on-ecs' ? (
-          <Zap size={16} className="text-primary mt-0.5 flex-shrink-0" />
-        ) : (
-          <Radio size={16} className="text-text-muted mt-0.5 flex-shrink-0" />
-        )}
-        <div className="flex-1">
-          <p className="text-sm font-medium text-text-primary">
-            {deployMode === 'always-on-ecs' ? '⚡ Always-on' : 'Serverless'}
-          </p>
-          <p className="text-xs text-text-muted mt-0.5">
-            {instructions.mode_note || (
-              deployMode === 'always-on-ecs'
-                ? 'Your agent runs 24/7. Open the Gateway Console below to manage your IM connections directly.'
-                : 'Your agent starts on demand. Connect via the company bot below.'
-            )}
-          </p>
-          {deployMode === 'always-on-ecs' && (
-            <GatewayConsoleButton />
-          )}
-        </div>
+      {/* Agent mode indicator — switching is in sidebar */}
+      <div className={`rounded-xl border px-3 py-2 flex items-center gap-2 text-xs ${effectiveMode === 'always-on' ? 'bg-success/5 border-success/20 text-success' : 'bg-surface-dim border-dark-border/40 text-text-muted'}`}>
+        {effectiveMode === 'always-on' ? <Zap size={14} /> : <Radio size={14} />}
+        <span>Configuring IM for: <strong>{effectiveMode === 'always-on' ? 'Always-On Agent' : 'Serverless Agent'}</strong></span>
+        {hasAlwaysOn && <span className="ml-auto text-[10px]">Switch agent in sidebar ←</span>}
       </div>
+
+      {/* Always-On Mode: show per-channel credential input cards */}
+      {effectiveMode === 'always-on' && (
+        <>
+          <div className="rounded-xl bg-success/5 border border-success/20 px-4 py-3 flex items-start gap-3">
+            <Zap size={16} className="text-success mt-0.5 flex-shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-text-primary">Always-On Agent — Direct IM Connection</p>
+              <p className="text-xs text-text-muted mt-0.5">
+                Create a personal bot on each IM platform and enter the credentials below.
+                Your agent connects directly — no shared routing, instant response.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {CHANNELS.filter(ch => alwaysOnAllowed.length === 0 || alwaysOnAllowed.includes(ch.id)).map(ch => {
+              const isConn = aoConnected.includes(ch.id);
+              return (
+                <Card key={ch.id} className="transition-all cursor-pointer hover:border-success/40">
+                  <div className="flex items-start gap-3">
+                    <div className="flex-shrink-0 mt-0.5">{(() => { const Icon = IM_ICONS[ch.id]; return Icon ? <Icon size={28} /> : null; })()}</div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+                        <h3 className="text-sm font-semibold text-text-primary">{ch.label}</h3>
+                        {isConn && <Badge color="success" dot>Connected</Badge>}
+                      </div>
+                      <p className="text-xs text-text-muted">
+                        {isConn ? 'Personal bot connected to your Always-On agent' : 'Create a bot and enter credentials to connect'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-3">
+                    {isConn ? (
+                      <div className="flex gap-2">
+                        <Button variant="ghost" size="sm" className="flex-1 text-xs" onClick={() => setSelectedAOChannel(ch)}>Reconfigure</Button>
+                        <Button variant="ghost" size="sm" className="text-text-muted hover:text-danger hover:border-danger/30"
+                          onClick={async () => { await api.del(`/portal/agent/channels/${ch.id}`); setAoConnected(prev => prev.filter(c => c !== ch.id)); }}>
+                          Disconnect
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button variant="primary" size="sm" className="w-full" onClick={() => setSelectedAOChannel(ch)}>
+                        <Key size={13} /> Enter Credentials
+                      </Button>
+                    )}
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Serverless Mode: show shared bot banner */}
+      {effectiveMode === 'serverless' && (
+        <div className="rounded-xl bg-surface-dim border border-dark-border/40 px-4 py-3 flex items-start gap-3">
+          <Radio size={16} className="text-text-muted mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm font-medium text-text-primary">Serverless — Company Shared Bot</p>
+            <p className="text-xs text-text-muted mt-0.5">
+              {instructions.mode_note || 'Connect via the company-wide bot. Your messages are routed to your personal agent on demand.'}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Serverless: show channel pairing cards. Always-on: show status only */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/enterprise/admin-console/src/pages/portal/Chat.tsx
+++ b/enterprise/admin-console/src/pages/portal/Chat.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Send, Bot, User, Loader2, Trash2, Zap } from 'lucide-react';
+import { Send, Bot, User, Loader2, Trash2, Zap, Radio, Shield, Clock } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { useAuth } from '../../contexts/AuthContext';
+import { usePortalAgent } from '../../contexts/PortalAgentContext';
 import { api } from '../../api/client';
 import ClawForgeLogo from '../../components/ClawForgeLogo';
 
@@ -36,9 +37,9 @@ function markAgentWarm(userId: string) {
 
 // ── Warmup indicator — only shown on first-ever connection ──────────────────
 
-function WarmupIndicator() {
+function WarmupIndicator({ seconds = 25 }: { seconds?: number }) {
   const [visible, setVisible] = useState(false);
-  const [remaining, setRemaining] = useState(6);
+  const [remaining, setRemaining] = useState(seconds);
 
   useEffect(() => {
     const show = setTimeout(() => setVisible(true), 1000);
@@ -60,7 +61,7 @@ function WarmupIndicator() {
     );
   }
 
-  const pct = Math.round(((6 - remaining) / 6) * 100);
+  const pct = Math.round(((seconds - remaining) / seconds) * 100);
   return (
     <div className="rounded-xl bg-dark-card border border-warning/30 px-4 py-3 w-72 space-y-2">
       <div className="flex items-center justify-between">
@@ -72,7 +73,7 @@ function WarmupIndicator() {
       <div className="h-1 w-full rounded-full bg-dark-border overflow-hidden">
         <div className="h-full rounded-full bg-warning transition-[width] duration-1000" style={{ width: `${pct}%` }} />
       </div>
-      <p className="text-[10px] text-text-muted">First message · cold-start ~10s — subsequent responses are instant</p>
+      <p className="text-[10px] text-text-muted">First message · cold-start ~{seconds}s — subsequent responses are instant</p>
     </div>
   );
 }
@@ -83,18 +84,22 @@ export default function PortalChat() {
   const { user } = useAuth();
   const userId = user?.id || 'unknown';
   const [searchParams] = useSearchParams();
-  const [agentType, setAgentType] = useState<'serverless' | 'always-on'>(
-    searchParams.get('agent') === 'always-on' ? 'always-on' : 'serverless'
-  );
+  const { agentType, hasAlwaysOn, alwaysOnInfo: aoCtx } = usePortalAgent();
+  // Map context info to local shape for compatibility
+  const alwaysOnInfo = aoCtx ? { tier: aoCtx.tier, status: aoCtx.status, enabled: hasAlwaysOn, running: aoCtx.running } : null;
+
+  const welcomeMessage = (type: 'serverless' | 'always-on'): Message => ({
+    id: 0, role: 'assistant',
+    content: type === 'always-on'
+      ? `Hello ${user?.name || 'there'}! I'm your **dedicated Always-On Agent** (${alwaysOnInfo?.tier || 'Fargate'} tier).\n\nI'm always running and ready to respond instantly. I can also proactively assist you via scheduled tasks (HEARTBEAT). How can I help?`
+      : `Hello ${user?.name || 'there'}! I'm your **${user?.positionName || 'AI'} Agent** at ACME Corp.\n\nI can help you with tasks related to your ${user?.positionName || ''} role in the ${user?.departmentName || ''} department. Just type your question or request below.\n\n> _Note: First message may take ~10s (cold start). Subsequent responses are faster._`,
+    timestamp: new Date().toISOString(),
+  });
 
   const [messages, setMessages] = useState<Message[]>(() => {
     const saved = loadMessages(userId);
     if (saved.length > 0) return saved;
-    return [{
-      id: 0, role: 'assistant',
-      content: `Hello ${user?.name || 'there'}! I'm your **${user?.positionName || 'AI'} Agent** at ACME Corp.\n\nI can help you with tasks related to your ${user?.positionName || ''} role in the ${user?.departmentName || ''} department. Just type your question or request below.`,
-      timestamp: new Date().toISOString(),
-    }];
+    return [welcomeMessage(agentType)];
   });
 
   const [input, setInput] = useState('');
@@ -166,38 +171,60 @@ export default function PortalChat() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-dark-border px-6 py-3">
+      {/* Header — visually differentiated by agent mode */}
+      <div className={`flex items-center justify-between border-b px-6 py-3 ${
+        agentType === 'always-on' ? 'border-success/20 bg-success/5' : 'border-dark-border'
+      }`}>
         <div className="flex items-center gap-3">
           <ClawForgeLogo size={36} animate={sending ? 'working' : 'idle'} />
           <div>
-            <h1 className="text-sm font-semibold text-text-primary">{user?.positionName} Agent</h1>
-            <p className="text-xs text-text-muted">{user?.name} · {user?.departmentName}</p>
+            <div className="flex items-center gap-2">
+              <h1 className="text-sm font-semibold text-text-primary">{user?.positionName} Agent</h1>
+              {agentType === 'always-on' ? (
+                <span className="flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-medium text-success">
+                  <Zap size={10} /> Always-On {alwaysOnInfo?.tier ? `· ${alwaysOnInfo.tier}` : ''}
+                </span>
+              ) : (
+                <span className="flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-medium text-primary-light">
+                  <Radio size={10} /> On-demand
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-text-muted">
+              {user?.name} · {user?.departmentName}
+              {agentType === 'always-on'
+                ? ' · Instant response · HEARTBEAT enabled'
+                : ' · ~10s cold start · Shared infrastructure'}
+            </p>
           </div>
         </div>
         <div className="flex items-center gap-3">
+          {/* Connection status */}
           <div className="flex items-center gap-1.5">
-            <div className={`w-2 h-2 rounded-full ${warm ? 'bg-success' : 'bg-warning'} animate-pulse`} />
-            <span className={`text-xs ${warm ? 'text-success' : 'text-warning'}`}>
-              {warm ? 'Connected' : 'Standby'}
-            </span>
+            {agentType === 'always-on' ? (
+              <>
+                <div className={`w-2 h-2 rounded-full ${alwaysOnInfo?.status === 'RUNNING' || warm ? 'bg-success' : 'bg-warning'} animate-pulse`} />
+                <span className={`text-xs ${alwaysOnInfo?.status === 'RUNNING' || warm ? 'text-success' : 'text-warning'}`}>
+                  {alwaysOnInfo?.status === 'RUNNING' || warm ? 'Running' : 'Starting'}
+                </span>
+              </>
+            ) : (
+              <>
+                <div className={`w-2 h-2 rounded-full ${warm ? 'bg-success' : 'bg-zinc-500'}`} />
+                <span className={`text-xs ${warm ? 'text-success' : 'text-text-muted'}`}>
+                  {warm ? 'Warm' : 'Cold'}
+                </span>
+              </>
+            )}
           </div>
-          <div className="flex rounded-lg border border-dark-border overflow-hidden text-xs">
-            <button
-              onClick={() => setAgentType('serverless')}
-              className={`px-2.5 py-1 flex items-center gap-1 transition-colors ${agentType === 'serverless' ? 'bg-primary/20 text-primary' : 'text-text-muted hover:bg-dark-hover'}`}>
-              <Bot size={12} /> Serverless
-            </button>
-            <button
-              onClick={() => setAgentType('always-on')}
-              className={`px-2.5 py-1 flex items-center gap-1 transition-colors ${agentType === 'always-on' ? 'bg-success/20 text-success' : 'text-text-muted hover:bg-dark-hover'}`}>
-              <Zap size={12} /> Always-On
-            </button>
-          </div>
+          {/* Agent mode shown as read-only badge — switching is in sidebar */}
+          <span className={`text-[10px] rounded-lg px-2 py-1 ${agentType === 'always-on' ? 'bg-success/10 text-success' : 'bg-dark-bg text-text-muted'}`}>
+            {agentType === 'always-on' ? '⚡ Always-On' : '📡 Serverless'}
+          </span>
           <button onClick={clearChat}
             className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
             title="Clear display only — agent memory is preserved">
-            <Trash2 size={14} /> Clear display
+            <Trash2 size={14} /> Clear
           </button>
         </div>
       </div>
@@ -234,8 +261,9 @@ export default function PortalChat() {
               <p className={`text-[10px] mt-1.5 ${msg.role === 'user' ? 'text-white/60' : 'text-text-muted'}`}>
                 {msg.role === 'user' && '✓ '}
                 {new Date(msg.timestamp).toLocaleTimeString()}
-                {msg.source === 'agentcore' && ' · AgentCore'}
-                {msg.source === 'always-on' && ' · Always-on'}
+                {msg.source === 'agentcore' && ' · AgentCore ⚡'}
+                {msg.source === 'fargate' && ' · Fargate 🟢'}
+                {msg.source === 'always-on' && ' · Always-On 🟢'}
                 {msg.model && ` · ${msg.model.split('/').pop()?.split(':')[0] || ''}`}
               </p>
             </div>
@@ -250,7 +278,7 @@ export default function PortalChat() {
         {sending && (
           <div className="flex gap-3">
             <div className="shrink-0 mt-1"><ClawForgeLogo size={28} animate="working" /></div>
-            {!warm ? <WarmupIndicator /> : (
+            {!warm ? <WarmupIndicator seconds={agentType === 'always-on' ? 3 : 25} /> : (
               <div className="rounded-xl bg-dark-card border border-dark-border px-4 py-3 flex items-center gap-2">
                 <Loader2 size={13} className="animate-spin text-text-muted" />
                 <span className="text-xs text-text-muted">Thinking...</span>
@@ -282,7 +310,10 @@ export default function PortalChat() {
         </div>
         <div className="flex items-center justify-between mt-2">
           <p className="text-[10px] text-text-muted">Press Enter to send</p>
-          <p className="text-[10px] text-text-muted">Powered by AWS Bedrock{warm && ' · Always-on'}</p>
+          <p className="text-[10px] text-text-muted">
+            Powered by AWS Bedrock
+            {agentType === 'always-on' ? ' · Dedicated Fargate Container' : ' · Shared AgentCore'}
+          </p>
         </div>
       </div>
     </div>

--- a/enterprise/admin-console/src/pages/portal/MyAgents.tsx
+++ b/enterprise/admin-console/src/pages/portal/MyAgents.tsx
@@ -94,7 +94,15 @@ export default function MyAgents() {
             <div>
               <h3 className="font-semibold text-text-primary">Always-On Agent</h3>
               {alwaysOn.enabled ? (
-                <p className="text-xs text-text-muted">{alwaysOn.tier} tier &middot; Instant response, HEARTBEAT enabled</p>
+                <p className="text-xs text-text-muted">
+                  {alwaysOn.tier} tier
+                  {alwaysOn.model ? ` · ${alwaysOn.model}` : ''}
+                  {' · '}Instant response
+                  {alwaysOn.createdAt ? ` · Uptime: ${(() => {
+                    const hrs = Math.floor((Date.now() - new Date(alwaysOn.createdAt).getTime()) / 3600000);
+                    return hrs < 24 ? `${hrs}h` : `${Math.floor(hrs / 24)}d ${hrs % 24}h`;
+                  })()}` : ''}
+                </p>
               ) : (
                 <p className="text-xs text-text-muted">Not configured</p>
               )}

--- a/enterprise/admin-console/src/pages/portal/MyUsage.tsx
+++ b/enterprise/admin-console/src/pages/portal/MyUsage.tsx
@@ -32,10 +32,10 @@ export default function MyUsage() {
       <h1 className="text-xl font-bold text-text-primary">My Usage</h1>
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <StatCard title="Requests" value={data.totalRequests} icon={<Zap size={22} />} color="primary" />
-        <StatCard title="Tokens" value={`${((data.totalInputTokens + data.totalOutputTokens) / 1000).toFixed(0)}k`} icon={<BarChart3 size={22} />} color="info" />
-        <StatCard title="Cost" value={`$${data.totalCost.toFixed(2)}`} icon={<DollarSign size={22} />} color="success" />
-        <StatCard title="Avg/Day" value={daily.length > 0 ? Math.round(data.totalRequests / daily.length) : 0} icon={<Clock size={22} />} color="cyan" />
+        <StatCard title="Requests" value={data.totalRequests || 0} icon={<Zap size={22} />} color="primary" />
+        <StatCard title="Tokens" value={`${(((data.totalInputTokens || 0) + (data.totalOutputTokens || 0)) / 1000).toFixed(0)}k`} icon={<BarChart3 size={22} />} color="info" />
+        <StatCard title="Cost" value={`$${(data.totalCost || 0).toFixed(2)}`} icon={<DollarSign size={22} />} color="success" />
+        <StatCard title="Avg/Day" value={daily.length > 0 ? Math.round((data.totalRequests || 0) / daily.length) : 0} icon={<Clock size={22} />} color="cyan" />
       </div>
 
       <Card>
@@ -55,7 +55,7 @@ export default function MyUsage() {
               <span className="text-sm text-text-secondary">{d.date}</span>
               <div className="flex items-center gap-4">
                 <span className="text-xs text-text-muted">{d.requests} requests</span>
-                <span className="text-sm font-medium text-text-primary">${d.cost.toFixed(4)}</span>
+                <span className="text-sm font-medium text-text-primary">${(d.cost || 0).toFixed(4)}</span>
               </div>
             </div>
           ))}

--- a/enterprise/docs/environments.md
+++ b/enterprise/docs/environments.md
@@ -11,6 +11,7 @@
 | **openclaw-jiade2** | 651770013524 | jiade2 | ap-northeast-1 | i-0344c501e6bdd0649 | c7g.large | https://openclaw.awspsa.com | wjiad@amazon |
 
 - CloudFront: `E21RJOMTNCOF1N` (default account 263168716248) → origin: Tokyo ALB `openclaw-tokyo-alb-*.ap-northeast-1.elb.amazonaws.com`
+- **VPC Origin PENDING:** `vo_JGVJb3n1UNEBsWbDg1u3Zo` (jiade2 account, Deployed, awaiting CF update)
 - OriginReadTimeout: 60s (updated 2026-04-14, was 30s)
 - S3 Bucket: `openclaw-tenants-651770013524`
 - DynamoDB: `openclaw-jiade2` (ap-northeast-1)
@@ -40,7 +41,10 @@
 |-------|---------|---------|--------|----------|------|-----|----------|
 | **openclaw-e2e-test** | 263168716248 | default | us-east-2 | i-054cb53703d2ba33c | c7g.large | https://dev-openclaw.awspsa.com | e2e-test-2026 |
 
-- CloudFront: `E1KNUZKAIOJVUA` (default account) → origin: EC2:8099 `ec2-3-128-78-89.us-east-2.compute.amazonaws.com`
+- CloudFront: `E1KNUZKAIOJVUA` (default account) → **VPC Origin** `vo_7fIxx0UYU1TFqzROnc4HQq` → EC2 private IP 10.0.1.29:8099
+- VPC Origin: Deployed, private network access (no public IP needed)
+- Subnet auto-assign public IP: **OFF** (next reboot removes public IP)
+- SG: `sg-0413dc66c2efd5e0a` — inbound 8099 from VPC CIDR 10.0.0.0/16 + CloudFront ENI SG `sg-07ff7b0dfc9c2d964`
 - OriginReadTimeout: 60s
 - S3 Bucket: `openclaw-e2e-test-263168716248`
 - DynamoDB: `openclaw-e2e-test` (us-east-2)

--- a/enterprise/docs/worklog-2026-04-14-phase2.md
+++ b/enterprise/docs/worklog-2026-04-14-phase2.md
@@ -1,0 +1,177 @@
+# Work Log — 2026-04-14 Phase 2 Session
+
+> Duration: ~8+ hours (extended all-day session, continuation of Phase 1)
+> Environments: Production (ap-northeast-1 openclaw-jiade2), Test (us-east-2 openclaw-e2e-test)
+> Branch: main
+> Commits: ed785b8..89c54a0 (11 commits)
+
+---
+
+## Overview
+
+Massive session completing Phase 2 of per-employee Fargate always-on agents. Designed PRD (618 lines, 31 items), implemented full stack across 4 phases (2A-2D), deployed to both environments, ran 72+ real Bedrock calls, merged 8 PRs, and deployed 12 production fixes.
+
+**Totals:** 18 files changed, +1,747 lines new code.
+
+---
+
+## Phase 2A: Infrastructure + Backend Core
+
+### PRD
+- Wrote `enterprise/docs/PRD-fargate-per-employee.md` (618 lines, 31 TODO items)
+- Covers: per-employee always-on agent lifecycle, EFS isolation, IM auto-connect, billing, cascade delete
+
+### CloudFormation (0b19bfb)
+- 4 per-tier IAM Task Roles (standard/restricted/engineering/executive)
+- 4 per-tier Security Groups
+- Proper least-privilege per tier
+
+### Backend (d2c3b73, df65b9d)
+- `admin_always_on.py`: per-employee Fargate management refactored
+  - EFS Access Point creation per employee
+  - Per-tier Role/SG assignment
+- `server.py`: channel management APIs + USAGE agent_type field
+- `entrypoint.sh`: IM credential auto-connect from DynamoDB on container start
+
+---
+
+## Phase 2B: Backend APIs + Admin Frontend
+
+### Backend APIs (1a63b62)
+- 7 new endpoints for always-on agent management:
+  - CRUD for per-employee agents
+  - Workspace S3/EFS APIs
+  - IM platform whitelist management
+
+### Admin Frontend (c996fe8)
+- AgentDetail page: Always-On card with enable/disable toggle
+- Security Center: Fargate overview tab
+- Agent Factory: per-employee agent management UI
+
+---
+
+## Phase 2C: Portal Frontend
+
+### Portal (d0b457e)
+- MyAgents page: employee sees their assigned agents
+- IM Connect modal: connect IM platforms to agents
+- Chat switcher: toggle between serverless and always-on agents
+- `portal.py`: 5 new endpoints (my-agents, channels add/remove, chat agent_type)
+
+---
+
+## Phase 2D: Billing + Lifecycle
+
+### Billing & Lifecycle (53bf9ff)
+- USAGE# records now include `agent_type` field (serverless vs always-on)
+- Fargate cost API: per-tier cost tracking
+- Cascade delete: removing employee cleans up Fargate agent + EFS + IM bindings
+- Position change warning: alerts when changing position affects always-on agent tier
+
+---
+
+## Frontend Fixes
+
+### TypeScript Build (f40631e)
+- Fixed TypeScript build errors introduced by Phase 2 frontend code
+- Clean compile with 0 errors
+
+### Employees Page Crash (89c54a0)
+- Bug: `channels.map()` on undefined crashed Employees page
+- Fix: added optional chaining `channels?.map()` with fallback empty array
+
+---
+
+## Production Deployment
+
+### 12 items deployed to openclaw.awspsa.com (Tokyo)
+
+| # | Change | Effect |
+|---|--------|--------|
+| 1 | Docker image: 13 skills -> 4 | Faster Gateway startup |
+| 2 | ThreadingMixIn | 502 errors eliminated |
+| 3 | Session Storage removed | SOUL identity injection restored |
+| 4 | S3 path injected in SOUL | Agent knows its workspace path |
+| 5 | 4 runtimes: MiniMax M2.5 / DeepSeek V3.2 / Sonnet 4.5 / Sonnet 4.6 | Model differentiation by tier |
+| 6 | SOUL identity injection verified | "I am EMP-003, Solutions Architect at ACME Corp" |
+| 7 | 502/504 errors fixed | Stable responses |
+| 8 | CloudFront timeout 30s -> 60s | Fewer 504s on complex tasks |
+| 9 | 8 PRs merged (#73-#80) | Community contributions integrated |
+
+### Verified on production
+- "Who am I?" -> correct employee identity
+- "Make me a PPT" -> generated and synced to S3
+- 4 different models correctly serving 4 tiers
+
+---
+
+## Test Environment Deployment
+
+- All Phase 2 code deployed (backend + frontend rebuilt)
+- 14/15 E2E tests passed via SSM localhost
+- CloudFront origin updated (new IP after reboot)
+- 72+ real Bedrock API calls across 4 tiers, 15+ employees, 4 models
+
+---
+
+## 8 PRs Merged
+
+| PR | Description |
+|----|-------------|
+| #73 | Update IM channel CLI docs |
+| #74 | Add StopRuntimeSession permission to EC2 host role |
+| #75 | Preserve runtime config during AgentCore updates |
+| #76 | Remove hardcoded sample admin login from deploy output |
+| #77 | Slack pairing alias fix |
+| #78 | Slack bootstrap auto-configure |
+| #79 | Strip IM wrappers before routing |
+| #80 | Community contribution |
+
+---
+
+## Known Issues at Session End
+
+### Frontend UX (user feedback)
+1. **Portal Chat** — serverless/always-on switcher UX not differentiated enough
+2. **Create Fargate Agent** — missing config template selector (tier/model/guardrail/resource)
+3. **IM Connect page** — no agent selector (serverless shared bot vs always-on direct)
+4. **Agent Factory detail** — "Enable Always-On" button loading forever / timeout
+5. **Employees page crash** — `channels.map()` on undefined — FIXED in code (89c54a0)
+
+### Test Environment Instability
+- EC2 was t4g.small (2 GB RAM) — OOM during Docker build
+- CloudFormation update rolled back (S3 bucket name conflict)
+- SG rules reset on each reboot (CFN rollback state)
+- Need upgrade to c7g.large or fix CFN template
+
+---
+
+## Key Files Changed
+
+| File | Purpose |
+|------|---------|
+| PRD-fargate-per-employee.md | Complete PRD (618 lines, 31 items) |
+| admin_always_on.py | Per-employee Fargate with EFS Access Point + per-tier Role/SG |
+| server.py | Channel APIs + USAGE agent_type + Session Storage removed |
+| agents.py | Always-on management + workspace S3/EFS APIs |
+| security.py | Fargate overview + IM platform whitelist |
+| portal.py | My-agents + channels add/remove + chat agent_type |
+| entrypoint.sh | DynamoDB IM credential auto-connect |
+| CloudFormation YAML | 4 Task Roles + 4 Security Groups |
+| MyAgents.tsx | Portal: employee's agent list |
+| AgentDetail.tsx | Admin: Always-On enable/disable card |
+| SecurityCenter Fargate tab | Admin: tier overview |
+| Chat switcher | Portal: serverless/always-on toggle |
+| useApi.ts | 8 new hooks for Phase 2 endpoints |
+
+---
+
+## Test Environment State (session end)
+
+| Resource | Status |
+|----------|--------|
+| EC2 i-054cb53703d2ba33c | running (t4g.small, OOM risk) |
+| SG sg-0413dc66c2efd5e0a | Rules reset after each reboot |
+| CloudFront E1KNUZKAIOJVUA | Origin updated |
+| DynamoDB | 18 USAGE, 251 AUDIT, 83 SESSION records |
+| ECS Cluster | openclaw-e2e-test-always-on (no services running) |

--- a/enterprise/docs/worklog-2026-04-14-session3.md
+++ b/enterprise/docs/worklog-2026-04-14-session3.md
@@ -1,0 +1,144 @@
+# Work Log — 2026-04-14 Session 3 (Frontend Fargate Overhaul)
+
+> Duration: ~6 hours
+> Environment: Test (us-east-2 dev-openclaw.awspsa.com)
+> Branch: main (uncommitted)
+
+---
+
+## Infrastructure Changes
+
+### EC2 Upgrade
+- t4g.small (2GB) → c7g.large (4GB) — 解决 OOM 问题
+- Instance: i-054cb53703d2ba33c, new IP: 3.145.94.125
+
+### CloudFront VPC Origins
+- **Test env (DONE):** VPC Origin `vo_7fIxx0UYU1TFqzROnc4HQq` → CloudFront `E1KNUZKAIOJVUA` 走私网访问 EC2
+  - SG: 允许 VPC CIDR 10.0.0.0/16 + CloudFront ENI SG 访问 8099
+  - 子网 auto-assign public IP 已关闭（下次重启后无公网 IP）
+  - 验证: 200 OK, 0.8s 响应
+- **Production (PENDING):** VPC Origin `vo_JGVJb3n1UNEBsWbDg1u3Zo` 已创建并 Deployed
+  - 跨账号: jiade2 (651770013524) → default (263168716248) CloudFront
+  - 等用户确认后更新 CloudFront `E21RJOMTNCOF1N`
+
+---
+
+## Frontend Changes — 已完成
+
+### P0 — Bug 修复 (5 项)
+| # | 页面 | 变更 |
+|---|------|------|
+| 1 | Dashboard | NaN% 除零保护, qualityScore 过滤修复, 频道图动态化, channels?.map 防 undefined |
+| 2 | MyUsage | totalRequests/totalCost/totalTokens 全加 `\|\| 0` 防 NaN |
+| 3 | App.tsx | 删除重复 `/portal/chat` 路由 |
+| 4 | AgentList Create | tier 选择器修复: `rt.runtimeId` → `rt.id`, 单选 radio 样式 |
+| 5 | AgentDetail | "Enable Always-On" 按钮移除, 改为指引去 Security Center |
+
+### P0 — 核心功能 (5 项)
+| # | 页面 | 变更 |
+|---|------|------|
+| 1 | BindIM | **AlwaysOnChannelConnect 组件** — per-channel 凭证输入表单 (飞书 app-id/secret, Telegram token, Slack bot/app token) |
+| 2 | BindIM | **Webhook URL 显示** — 从 alwaysOn.endpoint 拼接, 只读 + Copy 按钮 |
+| 3 | AgentDetail | Always-On 卡片增加 Model/IAM/Guardrail/Cost + Restart 按钮 |
+| 4 | AgentDetail | **Position 变更告警** — 检测 positionId 不匹配, 显示 warning + Restart Now |
+| 5 | Employees | **Cascade 删除清理提示** — Always-On 员工删除弹窗列出 ECS/EFS/IM/SSM/S3/DDB 清理 |
+
+### Portal 架构
+| # | 变更 |
+|---|------|
+| 1 | **PortalAgentContext** — 新建 React Context, 全局管理 agentType/hasAlwaysOn/alwaysOnInfo |
+| 2 | **PortalLayout sidebar** — Agent 切换器: Serverless 按钮 + Always-On 按钮 (未配置时灰色) |
+| 3 | **Chat.tsx** — 移除本地 agentType state, 改读 context; header 内 mode 改为只读 badge |
+| 4 | **BindIM.tsx** — 移除本地 agentMode selector, 改读 context; 显示 "Configuring IM for: X Agent" |
+
+### P1 — 管理监控 (5 项)
+| # | 页面 | 变更 |
+|---|------|------|
+| A | AgentDetail | **双 Agent Tab** — [📡 Serverless] [⚡ Always-On] tab, 各自独立显示 SOUL/Skills/Sessions/Config |
+| A | AgentDetail | **IM 白名单展示** — position 的 allowedIMPlatforms, 绿色/灰色标签 |
+| B | AgentDetail | **IM 审计日志** — 内联显示最近 5 条 IM 事件 |
+| C | SecurityCenter | **Fargate 成本汇总 + 批量操作** — Running/Stopped 数量 + 月费 + Stop All / Restart All |
+| C | SecurityCenter | **Fargate 卡片加 Configure 按钮** — 复用 RuntimeEditModal + New Fargate Template |
+| D | Usage | **Fargate Cost StatCard** — 显示 ~$X/mo + 容器数量 |
+| E | AuditLog | **4 个新事件类型** — always_on_enabled/disabled, im_channel_connected/disconnected |
+
+### P2 — UX 完善 (6 项)
+| # | 页面 | 变更 |
+|---|------|------|
+| 1 | MyAgents | Always-On 卡片加 Model 名称 + Uptime (Xd Xh) |
+| 2 | Chat | WarmupIndicator 动态秒数 — Serverless: 25s, Always-On: 3s |
+| 3 | AgentList | Always-On tab 每行加 Model 名称 + 月费估算 |
+| 4 | Workspace | useWorkspaceTree 新增 agentType 参数, 根据 deployMode 自动传 |
+| 5 | useApi | useAlwaysOnStatus 动态轮询 — starting: 5s, stable: 30s |
+| 6 | AgentDetail | IM Disconnect 加确认步骤 (Confirm? [Yes] [No]) |
+
+### 全页面 Fargate 适配
+| 页面 | 适配内容 |
+|------|----------|
+| Monitor | Sessions 表 + Agent Health 表加 Mode 列 (Serverless/Fargate badge), System Health 加 Fargate Agents 卡片, Agent Activity 加 Fargate badge |
+| Usage | By Agent 表加 Mode 列 |
+| Workspace | S3/EFS 存储类型 badge, SOUL 保存警告区分 always-on |
+| Settings | Platform Logs 加 Fargate Containers 选项, Service Status 加 ECS Fargate 卡片 |
+
+---
+
+## Frontend Changes — 未完成 (P3)
+
+| # | 问题 | 页面 | 说明 |
+|---|------|------|------|
+| P3-1 | Type 定义缺失 | types/index.ts | 无 AlwaysOnStatus/ContainerStatus/Tier 类型, 代码用 `any` |
+| P3-2 | Deploy Mode 枚举不完整 | 多处 | 'personal'/'always-on' 旧值未兼容 |
+| P3-3 | IM Disconnect 缺 reason 字段 | AgentDetail | 有确认但没有 reason 输入 (审计需要) |
+| P3-4 | Settings 缺 Fargate 全局配置 | Settings | 无 ECS 集群名/默认 tier/自动伸缩策略的配置 UI |
+| P3-5 | Portal 子页面未接入 context | MySkills/MyUsage/MyRequests/Profile | 未传 agent_type 给 API |
+| P3-6 | Workspace 文件操作缺 agent_type | Workspace | 读/写文件 API 没传 agent_type, 只有 tree 传了 |
+
+---
+
+## 其他未完成事项
+
+### 生产环境
+- [ ] CloudFront VPC Origin 切换 (已创建, 等确认执行)
+- [ ] 生产 EC2 的子网 auto-assign public IP 关闭
+- [ ] 生产 EC2 SG 收紧 (SSH 0.0.0.0/0 → 关闭, 只用 SSM)
+- [ ] 前端新版本部署到生产
+
+### 下个 Session 重点: E2E 测试
+- [ ] 编写测试用例覆盖全部前端页面
+- [ ] 真实数据 + 真实流程: Admin 创建 Fargate → 分配员工 → 员工连 IM → 对话 → 断开
+- [ ] 测试环境保留数据痕迹 (DynamoDB AUDIT/USAGE/SESSION/CONV)
+- [ ] 验证: Portal 双 Agent 切换, Chat 消息路由, Workspace S3/EFS, Monitor/Usage/Audit 数据正确
+- [ ] 后端 API 可用性: /portal/my-agents, /portal/agent/channels/add, /admin/channels/*, always-on CRUD
+- [ ] 稳定性: 容器重启后 IM 自动重连, EFS 数据持久, 级联删除完整
+
+### 代码状态
+- 所有改动未 commit (等用户说"提交")
+- TypeScript 0 错误
+- 已部署到测试环境 dev-openclaw.awspsa.com
+
+---
+
+## 文件改动列表 (22 files)
+
+| File | Lines Changed |
+|------|--------------|
+| enterprise/admin-console/src/contexts/PortalAgentContext.tsx | **NEW** (+55) |
+| enterprise/admin-console/src/components/PortalLayout.tsx | +45 |
+| enterprise/admin-console/src/pages/portal/Chat.tsx | +30 -25 |
+| enterprise/admin-console/src/pages/portal/BindIM.tsx | +150 -40 |
+| enterprise/admin-console/src/pages/portal/MyAgents.tsx | +8 -2 |
+| enterprise/admin-console/src/pages/portal/MyUsage.tsx | +4 -4 |
+| enterprise/admin-console/src/pages/AgentFactory/AgentDetail.tsx | +180 -80 |
+| enterprise/admin-console/src/pages/AgentFactory/AgentList.tsx | +35 -10 |
+| enterprise/admin-console/src/pages/SecurityCenter.tsx | +200 -70 |
+| enterprise/admin-console/src/pages/Dashboard.tsx | +15 -10 |
+| enterprise/admin-console/src/pages/Monitor/index.tsx | +20 -5 |
+| enterprise/admin-console/src/pages/Usage.tsx | +10 -5 |
+| enterprise/admin-console/src/pages/Workspace/index.tsx | +5 -2 |
+| enterprise/admin-console/src/pages/Settings.tsx | +5 -2 |
+| enterprise/admin-console/src/pages/AuditLog.tsx | +10 -2 |
+| enterprise/admin-console/src/pages/Organization/Employees.tsx | +15 -1 |
+| enterprise/admin-console/src/hooks/useApi.ts | +10 -4 |
+| enterprise/admin-console/src/App.tsx | -1 |
+| enterprise/docs/worklog-2026-04-14-phase2.md | **NEW** (补写) |
+| enterprise/docs/worklog-2026-04-14-session3.md | **NEW** (本文) |


### PR DESCRIPTION
## Summary
- **Portal**: Global agent switcher (Serverless / Always-On) in sidebar via PortalAgentContext
- **AgentDetail**: Dual Agent tabs with full config, IM whitelist, audit log, position change warning
- **BindIM**: Per-channel credential input forms (app-id/secret/token) + webhook URL display
- **SecurityCenter Fargate**: Card-based management with Configure, New Template, cost summary, bulk ops
- **All pages**: Fargate mode badges, NaN fixes, dynamic polling, agent_type API params

## Changes (21 files, +1382/-242)
- New: `PortalAgentContext.tsx` — global agent type state
- Modified: Portal (Chat, BindIM, MyAgents, MyUsage, PortalLayout)
- Modified: Admin (AgentDetail, AgentList, SecurityCenter, Dashboard, Monitor, Usage, Workspace, Settings, AuditLog, Employees)
- Updated: `useApi.ts` (workspace agent_type param, dynamic polling)
- Docs: environments.md (VPC Origin), worklogs

## Test plan
- [ ] Portal: sidebar agent switcher works, Chat shows correct mode badge
- [ ] Portal BindIM: Always-On mode shows credential forms, Serverless shows pairing
- [ ] AgentDetail: dual tabs render, Configure opens RuntimeEditModal
- [ ] SecurityCenter Fargate: cards show, Configure button works, cost bar visible
- [ ] Dashboard: no NaN errors
- [ ] Monitor/Usage: Mode column shows Fargate/Serverless badges
- [ ] TypeScript: 0 errors, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)