### PR TITLE
fix: replace $${ARCH} with ${!ARCH} in !Sub blocks to fix template validation error

### DIFF
--- a/eks/cloudformation/workshop-studio-template.yaml
+++ b/eks/cloudformation/workshop-studio-template.yaml
@@ -266,7 +266,7 @@ Resources:
               commands:
                 - echo "=== Installing Terraform ${TerraformVersion} ==="
                 - ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
-                - curl -fsSL "https://releases.hashicorp.com/terraform/${TerraformVersion}/terraform_${TerraformVersion}_linux_$${ARCH}.zip" -o /tmp/terraform.zip
+                - curl -fsSL "https://releases.hashicorp.com/terraform/${TerraformVersion}/terraform_${TerraformVersion}_linux_${!ARCH}.zip" -o /tmp/terraform.zip
                 - unzip -q /tmp/terraform.zip -d /usr/local/bin/ && rm /tmp/terraform.zip
                 - terraform version
             pre_build:
@@ -970,7 +970,7 @@ Resources:
                 - ARCH_ALT=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/')
                 - echo "=== Installing kubectl ==="
                 - !Sub |
-                  curl -fsSL "https://dl.k8s.io/release/v1.35.0/bin/linux/$${ARCH}/kubectl" -o /usr/local/bin/kubectl
+                  curl -fsSL "https://dl.k8s.io/release/v1.35.0/bin/linux/${!ARCH}/kubectl" -o /usr/local/bin/kubectl
                   chmod +x /usr/local/bin/kubectl
                   kubectl version --client
                 - echo "=== Installing helm ==="
@@ -978,7 +978,7 @@ Resources:
                 - helm version --short
                 - echo "=== Installing terraform ==="
                 - !Sub |
-                  curl -fsSL "https://releases.hashicorp.com/terraform/${TerraformVersion}/terraform_${TerraformVersion}_linux_$${ARCH}.zip" -o /tmp/terraform.zip
+                  curl -fsSL "https://releases.hashicorp.com/terraform/${TerraformVersion}/terraform_${TerraformVersion}_linux_${!ARCH}.zip" -o /tmp/terraform.zip
                   unzip -q /tmp/terraform.zip -d /usr/local/bin/ && rm /tmp/terraform.zip
                   terraform version
                 - echo "=== Installing eksctl ==="


### PR DESCRIPTION
…lidation error

[Issue 88](https://github.com/aws-samples/sample-OpenClaw-on-AWS-with-Bedrock/issues/88)

*Description of changes:*
fix: replace $${ARCH} with ${!ARCH} in !Sub blocks to fix template validation error.
&nbsp;
CloudFormation's dependency resolver scans for `${...}` patterns before processing the `$$`escape, causing **Unresolved resource dependencies [ARCH]** during template validation.

The `${!}` syntax is the officially documented escape mechanism for literal variable pass-through in [Fn::Sub](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-sub.html)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
