### PR TITLE
chore: set default value CreateVPCEndpoints to false

### DIFF
--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -77,7 +77,7 @@ Parameters:
 
   CreateVPCEndpoints:
     Type: String
-    Default: "true"
+    Default: "false"
     Description: "Create VPC endpoints for private network access to Bedrock and SSM"
     AllowedValues:
       - "true"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set `CreateVPCEndpoints` default parameter value to `false`

The reason to set this value to false:
1. To align with what stated in README.md that the default value for CreateVPCEndpoint is [false](https://github.com/aws-samples/sample-OpenClaw-on-AWS-with-Bedrock/blob/510600570e8c1ea5b603f4f9fcb3e787fe298d64/README.md?plain=1#L251)
2. Save additional cost for everyone that doesn't intentionally want to use VPC Endpoints but doesn't aware about that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
