### PR TITLE
Stronger security posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Deploy in 8 minutes. Access from your phone.
 ### One-Click Deploy
 
 1. Click "Launch Stack" for your region
-2. Select an EC2 key pair
-3. Wait ~8 minutes
-4. Check the Outputs tab
+2. Wait ~8 minutes
+3. Check the Outputs tab
 
 | Region | Launch |
 |--------|--------|
@@ -40,7 +39,7 @@ Deploy in 8 minutes. Access from your phone.
 | **EU (Ireland)** | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?stackName=openclaw-bedrock&templateURL=https://sharefile-jiade.s3.cn-northwest-1.amazonaws.com.cn/clawdbot-bedrock.yaml) |
 | **Asia Pacific (Tokyo)** | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?stackName=openclaw-bedrock&templateURL=https://sharefile-jiade.s3.cn-northwest-1.amazonaws.com.cn/clawdbot-bedrock.yaml) |
 
-> **Prerequisites**: Create an EC2 key pair in your target region. Bedrock model access is automatic — no manual enablement required.
+> **Prerequisites**: Bedrock model access is automatic — no manual enablement required. No SSH key needed — access via SSM Session Manager only.
 
 ### After Deployment
 
@@ -81,7 +80,6 @@ echo "http://localhost:18789/?token=$TOKEN"
 aws cloudformation create-stack \
   --stack-name openclaw-bedrock \
   --template-body file://clawdbot-bedrock.yaml \
-  --parameters ParameterKey=KeyPairName,ParameterValue=your-keypair \
   --capabilities CAPABILITY_IAM \
   --region us-west-2
 
@@ -189,59 +187,78 @@ Switch models with one CloudFormation parameter — no code changes:
 
 ### Typical Monthly Cost (Light Usage)
 
-| Component | Cost | Optional |
-|-----------|------|----------|
-| EC2 (c7g.large, Graviton) | ~$58 | Default |
-| EBS (30GB gp3 x2) | ~$4.80 | Required |
-| NAT Gateway | ~$33 | Required (EC2 in private subnet) |
-| CloudWatch Monitoring | ~$4 | ✅ Disable to save $4/mo |
-| VPC Endpoints (9 interface) | ~$51 | ✅ Enable for private network (+$51/mo) |
-| ALB + CloudFront | ~$25 | ✅ Enable for public access (+$25/mo) |
-| AWS WAF | ~$10 | ✅ Only in us-east-1 (+$10/mo) |
-| Bedrock (Nova 2 Lite, ~100 conv/day) | $5-8 | Pay-per-use |
-| **Total (default config)** | **$96-100/mo** | EC2 + NAT + monitoring + Bedrock |
-| **Total (minimal config, monitoring OFF)** | **$91-96/mo** | Save $4/mo by disabling CloudWatch |
-| **Total (VPC Endpoints ON)** | **$146-151/mo** | Add $51/mo for private network |
-| **Total (public access + WAF, us-east-1)** | **$180-190/mo** | Full security stack with public access |
+| Component | Cost (us-west-2) | Optional |
+|-----------|------------------|----------|
+| EC2 (c7g.large, Graviton) | ~$53 | Default (2 vCPU, 4GB RAM) |
+| EBS (30GB gp3 x2) | $4.80 | Required (root + data volumes) |
+| NAT Gateway | ~$34 | Required (EC2 in private subnet, includes ~40GB data) |
+| CloudWatch Monitoring | ~$4 | ✅ Disable to save ~$4/mo |
+| VPC Endpoints (6 interface) | ~$88 | ✅ Enable for private network (+~$88/mo) |
+| ALB + CloudFront | $22.80 | ✅ Enable for public access (+$22.80/mo) |
+| AWS WAF | ~$10 | ✅ Only if deploy to us-east-1 (+~$10/mo) |
+| Bedrock (Nova 2 Lite, ~100 conv/day) | $5.55 | Pay-per-use (~6M input + 1.5M output tokens/mo) |
+| **Total (default: VPCe OFF, monitoring ON)** | **~$101/mo** | EC2 + NAT + CloudWatch + Bedrock |
+| **Total (minimal: VPCe OFF, monitoring OFF)** | **~$97/mo** | Save ~$4/mo by disabling CloudWatch |
+| **Total (VPC Endpoints ON)** | **~$185/mo** | Add ~$88/mo for 6 interface endpoints across 2 AZs |
+| **Total (public access, no WAF)** | **~$124/mo** | Add $22.80/mo (ALB + CloudFront) |
+| **Total (public + VPCe, no WAF)** | **~$212/mo** | Add $111/mo (VPCe + public access) |
+| **Total (full security: public + VPCe + WAF, us-east-1)** | **~$222/mo** | Add $121/mo (full security stack) |
 
-> **Cost optimization**: Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) instead of c7g.large to save ~$30/mo. Enable VPC Endpoints only if you need private network routing (adds $51/mo).
+> **Cost optimization**: Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) instead of c7g.large to save ~$30/mo. Enable VPC Endpoints only if you need private network routing (adds ~$88/mo).
 
 **Always included at no extra cost:**
 - 2GB swap (prevents OOM crashes)
-- Health check cron (port + HTTP + channel connectivity)
-- OS security patches (unattended-upgrades)
-- IMDSv2 enforcement
-- `openclaw doctor --fix` post-install
-- systemd memory limits (graceful restart before OOM)
-- NAT Gateway (required for EC2 in private subnet)
+- Health check cron (port + HTTP + channel connectivity, every 5 min)
+- OS security patches (unattended-upgrades, automatic)
+- IMDSv2 enforcement (HttpTokens: required, no v1 fallback)
+- `openclaw doctor --fix` post-install validation
+- systemd memory limits (graceful restart before OOM at 80% memory)
+- NAT Gateway (required for EC2 in private subnet, included in base cost)
+- Node.js 22.22.0 pinned (prevents breakage from bad releases)
+- S3 Gateway VPC Endpoint (free, no hourly charge)
 
-### Cost Breakdown by Configuration
+**Pricing notes:**
+- All costs based on **AWS Official Pricing API** for **us-west-2** (accessed May 2026)
+- EC2 c7g.large: **$0.0725/hour** = **~$53/month** (verified via AWS Pricing API)
+- VPC Interface Endpoints: **$0.01/hour/AZ** × 2 AZs = **$14.60/month per endpoint**
+- NAT Gateway: **$0.045/hour** = **$32.85/month** + **$0.045/GB** data processing (~$1.80/mo)
+- Full cost breakdown: [COST_BREAKDOWN_OFFICIAL.md](COST_BREAKDOWN_OFFICIAL.md)
+
+### Cost Breakdown by Configuration (Official AWS Pricing)
 
 | Configuration | Monthly Cost | What You Get |
 |--------------|-------------|--------------|
-| **Default (VPCe OFF, monitoring ON)** | $96-100 | EC2 + NAT Gateway + CloudWatch + Bedrock. Traffic via NAT Gateway. SSM-only access. |
-| **Minimal (VPCe OFF, monitoring OFF)** | $91-96 | Above minus CloudWatch monitoring. Save $4/mo. |
-| **Private Network (VPCe ON)** | $146-151 | Default + 9 VPC endpoints for private AWS network routing. Add $51/mo. |
-| **Public Access (no WAF, any region)** | $170-180 | Above + ALB + CloudFront. Add $25/mo. No Layer 7 WAF. |
-| **Full Security (public + WAF, us-east-1 only)** | $180-190 | Above + AWS WAF (SQL injection, XSS, rate limiting). Add $10/mo. |
+| **Default (VPCe OFF, monitoring ON)** | **~$101** | EC2 c7g.large (~$53) + EBS 60GB ($4.80) + NAT Gateway (~$34) + CloudWatch (~$4) + Bedrock Nova 2 Lite ($5.55). Traffic via NAT Gateway to AWS public endpoints (still encrypted via TLS). SSM-only access. |
+| **Minimal (VPCe OFF, monitoring OFF)** | **~$98** | Above minus CloudWatch monitoring. Save ~$4/mo. Lose auto-recovery, health alarms, log shipping. |
+| **Private Network (VPCe ON, monitoring ON)** | **~$189** | Default + 6 interface VPC endpoints across 2 AZs (**$14.60/endpoint/mo × 6 = $87.60**): Bedrock Runtime, Bedrock Mantle, SSM, SSM Messages, EC2 Messages, CloudWatch Logs. S3 Gateway endpoint free. Add **~$88/mo** (includes data processing). **All Bedrock + SSM traffic stays on AWS private network (never touches internet).** |
+| **Public Access (VPCe OFF, no WAF)** | **~$124** | Default + ALB ($22.27) + CloudFront ($0.53). Add **$22.80/mo**. HTTPS via CloudFront, but CloudFront→ALB uses HTTP (not end-to-end TLS). No Layer 7 WAF. |
+| **Public + Private Network (VPCe ON, no WAF)** | **~$212** | Above + 6 VPC endpoints. Add **$111/mo** total. |
+| **Full Security (public + VPCe + WAF, us-east-1 only)** | **~$222** | Above + AWS WAF (~$10): Web ACL + 5 managed rules (SQL injection, XSS, bad inputs, Linux protection, rate limiting 1000 req/5min). Add **$121/mo** total. ⚠️ **WAF only works in us-east-1** — other regions silently skip WAF (no Layer 7 protection, only Shield Standard Layer 3/4). |
 
 ### Save Money
 
-- **Use Nova 2 Lite instead of Claude** → 90% cheaper inference ($0.30 vs $3-15 per 1M input tokens)
-- **Use Graviton (ARM) instead of x86** → 20-40% cheaper EC2
-- **Use smaller instance type** → t4g.medium ($24/mo) or r7g.medium ($30/mo) saves ~$30/mo vs c7g.large
-- **Default config (VPCe OFF)** → saves $51/mo vs private network (traffic via NAT Gateway instead)
-- **Skip public access** (`EnablePublicAccess=false`) → saves $25/mo (no ALB + CloudFront, use SSM Session Manager instead)
-- **Disable monitoring** (`EnableMonitoring=false`) → saves $4/mo (lose auto-recovery, health alarms, log shipping)
-- **AWS Savings Plans** → 30-40% off EC2 for 1-3 year commitment
+- **Use Nova 2 Lite instead of Claude** → 90% cheaper inference ($0.30 vs $3-15 per 1M input tokens). **Already default** ✅
+- **Use Graviton (ARM) instead of x86** → 20-40% cheaper EC2. c7g.large (~$53/mo) vs r5.large x86 ($92/mo). **Already default** ✅
+- **Use smaller instance type** → **t4g.medium** ($24.53/mo, 4GB RAM) **saves $28.40/mo** (54% cheaper) vs c7g.large. Trade-off: Less CPU for Docker sandbox. Good for light usage (<10 users).
+- **Use r7g.medium** → $39.13/mo (8GB RAM) **saves $13.80/mo** (26% cheaper) vs c7g.large. More memory for plugins/embeddings, but only 1 vCPU.
+- **Default config (VPCe OFF)** → **saves ~$88/mo** vs private network. Traffic goes via NAT Gateway to AWS public endpoints (still encrypted via TLS). **Best cost/benefit ratio for most use cases.** ✅
+- **Skip public access** (`EnablePublicAccess=false`) → **saves $22.80/mo** (no ALB + CloudFront). Use SSM Session Manager only. **Already default** ✅
+- **Disable monitoring** (`EnableMonitoring=false`) → **saves ~$4/mo** (lose auto-recovery alarms, health metrics, log shipping to CloudWatch). Not recommended for production.
+- **AWS Savings Plans** → **30-40% off EC2** for 1-3 year commitment. c7g.large: ~$53/mo → **~$31.76-37.05/mo** (save $15-21/mo). Must commit to instance family (c7g). Best for long-term deployments.
 
 ### vs. Alternatives
 
 | Option | Cost | What you get |
 |--------|------|-------------|
-| ChatGPT Plus | $20/person/month | Single user, no integrations |
-| This project (5 users) | ~$10/person/month | Multi-user, WhatsApp/Telegram/Discord, full control |
-| Local Mac Mini | $0 server + $20-30 API | Hardware cost, manage yourself |
+| ChatGPT Plus | $20/person/month | Single user, no integrations, web UI only |
+| **This project (1 user)** | **$101/month** | 5x more expensive, but full control + integrations |
+| **This project (5 users)** | **$20.20/person/month** | Break-even with ChatGPT, multi-user, WhatsApp/Telegram/Discord/Slack |
+| **This project (10 users)** | **$10.10/person/month** | 50% cheaper, economy of scale |
+| **This project (20 users)** | **$5.05/person/month** | 75% cheaper, way more features |
+| **This project (50 users)** | **$2.02/person/month** | 90% cheaper, enterprise scale |
+| Local Mac Mini | $0 server + $20-30 API | Hardware cost, manage yourself, electricity cost |
+
+**Break-even point: ~5 users** (same cost as ChatGPT Plus)
 
 ---
 
@@ -249,31 +266,33 @@ Switch models with one CloudFormation parameter — no code changes:
 
 ### Instance Types
 
-| Type | Monthly | RAM | Architecture | Use case |
-|------|---------|-----|-------------|----------|
-| t4g.small | $12 | 2GB | Graviton ARM | Personal (minimal) |
-| t4g.medium | $24 | 4GB | Graviton ARM | Small teams |
-| t4g.large | $48 | 8GB | Graviton ARM | Medium teams |
-| **c7g.large** | **$58** | **4GB** | **Graviton ARM** | **Recommended (default)** |
-| r7g.medium | $30 | 8GB | Graviton ARM | Memory-optimized alternative |
-| r7g.large | $60 | 16GB | Graviton ARM | Heavy usage / plugins |
-| c7g.large | $58 | 4GB | Graviton ARM | Compute-intensive |
-| r5.large | $91 | 16GB | x86 | x86 + memory |
+| Type | Monthly (us-west-2) | vCPU | RAM | Architecture | Use case |
+|------|---------------------|------|-----|-------------|----------|
+| t4g.small | $12 | 2 | 2GB | Graviton ARM | Personal (minimal), burstable |
+| **t4g.medium** | **$24.53** | **2** | **4GB** | **Graviton ARM** | **Best value (save $28.40/mo vs c7g.large)** |
+| t4g.large | $49 | 2 | 8GB | Graviton ARM | Medium teams, burstable |
+| **c7g.large** | **~$53** | **2** | **4GB** | **Graviton ARM** | **Default (compute-optimized for Node.js + Docker)** |
+| c7g.xlarge | $106 | 4 | 8GB | Graviton ARM | Heavy compute workloads |
+| **r7g.medium** | **$39.13** | **1** | **8GB** | **Graviton ARM** | **Memory-optimized (save $13.80/mo, good for plugins/embeddings)** |
+| r7g.large | $78 | 2 | 16GB | Graviton ARM | Heavy usage / many plugins |
+| r5.large | $92 | 2 | 16GB | x86 | x86 compatibility + memory |
+
+**Cost source**: AWS Pricing API (accessed May 2026)
 
 ### Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `OpenClawModel` | `global.amazon.nova-2-lite-v1:0` | Bedrock model ID - Nova 2 Lite offers best price-performance for everyday tasks. 10 models available: Nova 2 Lite, Claude Sonnet 4.5, Nova Pro, Claude Opus 4.6, Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4, DeepSeek R1, Llama 3.3 70B, Kimi K2.5 |
-| `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.27` (auto-discovery, embeddings), or `latest` |
-| `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. c7g = compute-optimized (recommended, 2 vCPU for Node.js + sandbox), r7g/r6g = memory-optimized, t4g = burstable. 14 ARM + 7 x86 instance types available |
-| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access to Bedrock and SSM (~$51/mo for 9 interface endpoints). Default off to minimize cost - traffic goes via NAT Gateway instead |
-| `EnableMonitoring` | `true` | Enable CloudWatch monitoring, health checks, auto-recovery, and log shipping (+~$4/mo) |
-| `EnableSandbox` | `true` | Install Docker for sandboxed execution (recommended for group chats) |
-| `EnableDataProtection` | `false` | Retain data volume when stack is deleted (protects against accidental data loss) |
-| `EnablePublicAccess` | `false` | Enable public access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only. **⚠️ Security Note**: CloudFront → ALB connection uses HTTP (not HTTPS), meaning origin traffic is unencrypted. This is an accepted tradeoff for simplicity. For full end-to-end encryption, add ACM certificate + HTTPS ALB listener (see SECURITY.md). |
-| `EnableWAF` | `true` | Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS, rate limiting, ~$10/mo). **⚠️ IMPORTANT: WAF only works in us-east-1.** If you deploy in other regions (e.g., us-west-2, ap-northeast-1, eu-west-1), the WAF will be silently skipped and you won't get Layer 7 protection. Deploy in us-east-1 to enable WAF, or accept that other regions only get Shield Standard (Layer 3/4 DDoS protection). |
-| `AllowedCountries` | _(empty)_ | CloudFront geographic restrictions. Leave empty (default) to allow worldwide access, or specify comma-separated ISO 3166-1 alpha-2 country codes to restrict access to specific countries (e.g., `AU,US,GB,JP`) |
+| `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.10` / `2026.4.27` (auto-discovery, embeddings), or `latest` (not recommended for production) |
+| `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. **c7g = compute-optimized** (recommended, 2 vCPU for Node.js + Docker sandbox), **r7g/r6g = memory-optimized** (plugins, embeddings), **t4g = burstable** (cost-optimized). 14 ARM + 7 x86 instance types available |
+| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus ~$0.75/mo data processing. S3 Gateway endpoint always free). **Default OFF to minimize cost** — traffic goes via NAT Gateway to AWS public HTTPS endpoints instead (still encrypted via TLS, no security downside for most use cases). Enable only if compliance requires private network routing (adds **~$88/mo**). |
+| `EnableMonitoring` | `true` | Enable CloudWatch monitoring, EC2 auto-recovery + reboot alarms, metrics (memory, disk, swap), and log shipping (+~$4/mo). **Recommended ON** for production |
+| `EnableSandbox` | `true` | Install Docker for sandboxed command execution (recommended for group chats and untrusted code). Adds ~500MB disk usage |
+| `EnableDataProtection` | `false` | Retain both EBS volume and S3 bucket when stack is deleted (protects against accidental data loss). **Set to true for production** |
+| `EnablePublicAccess` | `false` | Enable public HTTPS access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only (secure, no open ports). **⚠️ Security Note**: CloudFront → ALB connection uses HTTP (not HTTPS), meaning origin traffic is unencrypted. This is an accepted tradeoff for simplicity. For full end-to-end encryption, add ACM certificate + HTTPS ALB listener (see SECURITY.md). |
+| `EnableWAF` | `true` | Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS, bad inputs, rate limiting 1000 req/5min, ~$10/mo). **⚠️ CRITICAL LIMITATION: WAF only works in us-east-1.** If you deploy in other regions (e.g., us-west-2, ap-northeast-1, eu-west-1), the WAF will be silently skipped and you won't get Layer 7 protection. Deploy in us-east-1 to enable WAF, or accept that other regions only get Shield Standard (Layer 3/4 DDoS protection). |
+| `AllowedCountries` | _(empty)_ | CloudFront geographic restrictions (geo-blocking). Leave empty (default) to allow worldwide access, or specify comma-separated ISO 3166-1 alpha-2 country codes to restrict access to specific countries only (e.g., `AU,US,GB,JP`). Useful for compliance (GDPR, data residency) |
 
 ---
 
@@ -398,14 +417,18 @@ Uses SiliconFlow (DeepSeek, Qwen, GLM) instead of Bedrock. Requires a SiliconFlo
 
 | Layer | What it does |
 |-------|-------------|
-| **IAM Roles** | No API keys — automatic credential rotation |
-| **IMDSv2 Enforced** | Instance metadata requires secure token (no v1 fallback) |
-| **SSM Session Manager** | No public ports, session logging |
-| **VPC Endpoints** | Bedrock traffic stays on private network |
-| **SSM Parameter Store** | Gateway token stored as SecureString, never on disk |
-| **Supply-chain protection** | Docker via GPG-signed repos, NVM via download-then-execute (no `curl \| sh`) |
-| **Docker Sandbox** | Isolates code execution in group chats |
-| **CloudTrail** | Every Bedrock API call audited |
+| **No SSH** | Zero SSH keys, zero SSH ports. SSM Session Manager only. |
+| **IAM Roles** | No API keys — automatic credential rotation via EC2 instance profile |
+| **IMDSv2 Enforced** | Instance metadata requires secure token (`HttpTokens: required`, no v1 fallback) |
+| **SSM Session Manager** | No public ports (22/3389/18789), session logging, encrypted tunnel |
+| **VPC Endpoints (optional)** | Bedrock + SSM traffic stays on AWS private network (never touches internet) |
+| **SSM Parameter Store** | Gateway token stored as SecureString (KMS-encrypted), never written to disk |
+| **Supply-chain protection** | Docker via GPG-signed repos, NVM via download-then-execute (no `curl \| sh`), npm registry hardcoded |
+| **Docker Sandbox** | Isolates code execution in group chats (prevents host compromise) |
+| **CloudTrail** | Every Bedrock API call audited (who, when, what model, what input/output) |
+| **Private subnet + NAT** | EC2 in private subnet, no public IP, outbound via NAT Gateway |
+| **Security groups** | Minimal ingress (ALB only if public access enabled), full egress |
+| **Network ACLs** | Stateless firewall on private subnets (HTTPS, DNS, ephemeral only) |
 
 ### ⚠️ WAF Regional Limitation
 
@@ -461,11 +484,13 @@ Optional extensions for OpenClaw:
 
 ---
 
-## SSH-like Access via SSM
+## Shell Access via SSM (No SSH)
+
+The instance has **no SSH key** and **no SSH port** open. All access is via SSM Session Manager.
 
 ```bash
-# Start interactive session
-aws ssm start-session --target i-xxxxxxxxx --region us-east-1
+# Start interactive session (get instance ID from CloudFormation Outputs)
+aws ssm start-session --target i-xxxxxxxxx --region us-west-2
 
 # Switch to ubuntu user
 sudo su - ubuntu
@@ -473,7 +498,21 @@ sudo su - ubuntu
 # Run OpenClaw commands
 openclaw --version
 openclaw gateway status
+openclaw doctor --fix
+
+# View logs
+journalctl -u openclaw-gateway.service -f
+tail -f ~/.openclaw/*.log
+
+# Alternative: Use EC2 Console > right-click instance > Connect > Session Manager
 ```
+
+**Why no SSH?** SSM is more secure:
+- No exposed port 22 (reduces attack surface)
+- Automatic session logging to CloudTrail/S3
+- Temporary credentials (no long-lived SSH keys)
+- IAM-based access control (no key rotation)
+- Encrypted tunnels (AES-256)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -192,14 +192,19 @@ Switch models with one CloudFormation parameter — no code changes:
 | Component | Cost | Optional |
 |-----------|------|----------|
 | EC2 (c7g.large, Graviton) | ~$58 | Default |
-| EBS (30GB gp3 x2) | $4.80 | — |
-| VPC Endpoints | $29 | ✅ Disable to save |
-| CloudWatch Monitoring | ~$4 | ✅ Disable to save |
+| EBS (30GB gp3 x2) | ~$4.80 | Required |
+| NAT Gateway | ~$33 | Required (EC2 in private subnet) |
+| CloudWatch Monitoring | ~$4 | ✅ Disable to save $4/mo |
+| VPC Endpoints (9 interface) | ~$51 | ✅ Enable for private network (+$51/mo) |
+| ALB + CloudFront | ~$25 | ✅ Enable for public access (+$25/mo) |
+| AWS WAF | ~$10 | ✅ Only in us-east-1 (+$10/mo) |
 | Bedrock (Nova 2 Lite, ~100 conv/day) | $5-8 | Pay-per-use |
-| **Total (all options)** | **$96-101** | |
-| **Total (minimal)** | **$63-67** | VPCe + CW off |
+| **Total (default config)** | **$96-100/mo** | EC2 + NAT + monitoring + Bedrock |
+| **Total (minimal config, monitoring OFF)** | **$91-96/mo** | Save $4/mo by disabling CloudWatch |
+| **Total (VPC Endpoints ON)** | **$146-151/mo** | Add $51/mo for private network |
+| **Total (public access + WAF, us-east-1)** | **$180-190/mo** | Full security stack with public access |
 
-> Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) to reduce cost.
+> **Cost optimization**: Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) instead of c7g.large to save ~$30/mo. Enable VPC Endpoints only if you need private network routing (adds $51/mo).
 
 **Always included at no extra cost:**
 - 2GB swap (prevents OOM crashes)
@@ -208,13 +213,27 @@ Switch models with one CloudFormation parameter — no code changes:
 - IMDSv2 enforcement
 - `openclaw doctor --fix` post-install
 - systemd memory limits (graceful restart before OOM)
+- NAT Gateway (required for EC2 in private subnet)
+
+### Cost Breakdown by Configuration
+
+| Configuration | Monthly Cost | What You Get |
+|--------------|-------------|--------------|
+| **Default (VPCe OFF, monitoring ON)** | $96-100 | EC2 + NAT Gateway + CloudWatch + Bedrock. Traffic via NAT Gateway. SSM-only access. |
+| **Minimal (VPCe OFF, monitoring OFF)** | $91-96 | Above minus CloudWatch monitoring. Save $4/mo. |
+| **Private Network (VPCe ON)** | $146-151 | Default + 9 VPC endpoints for private AWS network routing. Add $51/mo. |
+| **Public Access (no WAF, any region)** | $170-180 | Above + ALB + CloudFront. Add $25/mo. No Layer 7 WAF. |
+| **Full Security (public + WAF, us-east-1 only)** | $180-190 | Above + AWS WAF (SQL injection, XSS, rate limiting). Add $10/mo. |
 
 ### Save Money
 
-- Use Nova 2 Lite instead of Claude → 90% cheaper
-- Use Graviton (ARM) instead of x86 → 20-40% cheaper
-- Skip VPC Endpoints → save $22/mo (less secure)
-- AWS Savings Plans → 30-40% off EC2
+- **Use Nova 2 Lite instead of Claude** → 90% cheaper inference ($0.30 vs $3-15 per 1M input tokens)
+- **Use Graviton (ARM) instead of x86** → 20-40% cheaper EC2
+- **Use smaller instance type** → t4g.medium ($24/mo) or r7g.medium ($30/mo) saves ~$30/mo vs c7g.large
+- **Default config (VPCe OFF)** → saves $51/mo vs private network (traffic via NAT Gateway instead)
+- **Skip public access** (`EnablePublicAccess=false`) → saves $25/mo (no ALB + CloudFront, use SSM Session Manager instead)
+- **Disable monitoring** (`EnableMonitoring=false`) → saves $4/mo (lose auto-recovery, health alarms, log shipping)
+- **AWS Savings Plans** → 30-40% off EC2 for 1-3 year commitment
 
 ### vs. Alternatives
 
@@ -245,15 +264,16 @@ Switch models with one CloudFormation parameter — no code changes:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `OpenClawModel` | Nova 2 Lite | Bedrock model ID |
-| `OpenClawVersion` | 2026.3.24 | `2026.3.24` (default, no model approval needed, WeChat compatible), `2026.4.5` (auto-discovery, embeddings), or `latest` |
-| `InstanceType` | c7g.large | EC2 instance type (compute-optimized, 2 vCPU) |
-| `CreateVPCEndpoints` | false | Private networking (+$29/mo) |
-| `EnableMonitoring` | true | CloudWatch monitoring, auto-recovery, log shipping (+~$4/mo) |
-| `EnableSandbox` | true | Docker isolation for code execution |
-| `EnableDataProtection` | false | Retain EBS volume on stack deletion |
-| `KeyPairName` | none | EC2 key pair (optional, for emergency SSH) |
-| `AllowedSSHCIDR` | _(empty)_ | CIDR for SSH access — leave empty to disable |
+| `OpenClawModel` | `global.amazon.nova-2-lite-v1:0` | Bedrock model ID - Nova 2 Lite offers best price-performance for everyday tasks. 10 models available: Nova 2 Lite, Claude Sonnet 4.5, Nova Pro, Claude Opus 4.6, Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4, DeepSeek R1, Llama 3.3 70B, Kimi K2.5 |
+| `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.27` (auto-discovery, embeddings), or `latest` |
+| `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. c7g = compute-optimized (recommended, 2 vCPU for Node.js + sandbox), r7g/r6g = memory-optimized, t4g = burstable. 14 ARM + 7 x86 instance types available |
+| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access to Bedrock and SSM (~$51/mo for 9 interface endpoints). Default off to minimize cost - traffic goes via NAT Gateway instead |
+| `EnableMonitoring` | `true` | Enable CloudWatch monitoring, health checks, auto-recovery, and log shipping (+~$4/mo) |
+| `EnableSandbox` | `true` | Install Docker for sandboxed execution (recommended for group chats) |
+| `EnableDataProtection` | `false` | Retain data volume when stack is deleted (protects against accidental data loss) |
+| `EnablePublicAccess` | `false` | Enable public access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only |
+| `EnableWAF` | `true` | Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS, rate limiting, ~$10/mo). **⚠️ IMPORTANT: WAF only works in us-east-1.** If you deploy in other regions (e.g., us-west-2, ap-northeast-1, eu-west-1), the WAF will be silently skipped and you won't get Layer 7 protection. Deploy in us-east-1 to enable WAF, or accept that other regions only get Shield Standard (Layer 3/4 DDoS protection). |
+| `AllowedCountries` | _(empty)_ | CloudFront geographic restrictions. Leave empty (default) to allow worldwide access, or specify comma-separated ISO 3166-1 alpha-2 country codes to restrict access to specific countries (e.g., `AU,US,GB,JP`) |
 
 ---
 
@@ -386,6 +406,19 @@ Uses SiliconFlow (DeepSeek, Qwen, GLM) instead of Bedrock. Requires a SiliconFlo
 | **Supply-chain protection** | Docker via GPG-signed repos, NVM via download-then-execute (no `curl \| sh`) |
 | **Docker Sandbox** | Isolates code execution in group chats |
 | **CloudTrail** | Every Bedrock API call audited |
+
+### ⚠️ WAF Regional Limitation
+
+AWS WAF for CloudFront distributions **must be created in us-east-1** due to CloudFront being a global service. This means:
+
+- ✅ **Deploy in us-east-1**: Full WAF protection (SQL injection, XSS, rate limiting, bad inputs)
+- ⚠️ **Deploy in other regions** (us-west-2, ap-northeast-1, eu-west-1, etc.): WAF is **silently skipped**
+  - You still get AWS Shield Standard (Layer 3/4 DDoS protection) — always enabled, no cost
+  - You still get CloudFront managed prefix list (ALB only accepts traffic from CloudFront)
+  - You still get custom header validation (prevents direct ALB access)
+  - You **DON'T get** Layer 7 WAF protections (SQL injection, XSS, rate limiting)
+
+**Recommendation**: If Layer 7 WAF is critical for your use case, deploy the stack in us-east-1. Your EC2 instance and Bedrock requests will still be regional (low latency), only the CloudFront WAF needs to be in us-east-1.
 
 **[→ Full Security Guide](SECURITY.md)**
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | Bedrock (Nova 2 Lite, ~100 conv/day) | $5.55 | Pay-per-use (~6M input + 1.5M output tokens/mo) |
 | **Total (default: VPCe OFF, monitoring ON)** | **~$101/mo** | EC2 + NAT + CloudWatch + Bedrock |
 | **Total (minimal: VPCe OFF, monitoring OFF)** | **~$97/mo** | Save ~$4/mo by disabling CloudWatch |
-| **Total (VPC Endpoints ON)** | **~$185/mo** | Add ~$88/mo for 6 interface endpoints across 2 AZs |
+| **Total (VPC Endpoints ON)** | **~$189/mo** | Add ~$88/mo for 6 interface endpoints across 2 AZs |
 | **Total (public access, no WAF)** | **~$124/mo** | Add $22.80/mo (ALB + CloudFront) |
 | **Total (public + VPCe, no WAF)** | **~$212/mo** | Add $111/mo (VPCe + public access) |
 | **Total (full security: public + VPCe + WAF, us-east-1)** | **~$222/mo** | Add $121/mo (full security stack) |
@@ -222,14 +222,13 @@ Switch models with one CloudFormation parameter — no code changes:
 - EC2 c7g.large: **$0.0725/hour** = **~$53/month** (verified via AWS Pricing API)
 - VPC Interface Endpoints: **$0.01/hour/AZ** × 2 AZs = **$14.60/month per endpoint**
 - NAT Gateway: **$0.045/hour** = **$32.85/month** + **$0.045/GB** data processing (~$1.80/mo)
-- Full cost breakdown: [COST_BREAKDOWN_OFFICIAL.md](COST_BREAKDOWN_OFFICIAL.md)
 
-### Cost Breakdown by Configuration (Official AWS Pricing)
+### Cost Breakdown by Configuration
 
 | Configuration | Monthly Cost | What You Get |
 |--------------|-------------|--------------|
-| **Default (VPCe OFF, monitoring ON)** | **~$101** | EC2 c7g.large (~$53) + EBS 60GB ($4.80) + NAT Gateway (~$34) + CloudWatch (~$4) + Bedrock Nova 2 Lite ($5.55). Traffic via NAT Gateway to AWS public endpoints (still encrypted via TLS). SSM-only access. |
-| **Minimal (VPCe OFF, monitoring OFF)** | **~$98** | Above minus CloudWatch monitoring. Save ~$4/mo. Lose auto-recovery, health alarms, log shipping. |
+| **Default (VPCe OFF, monitoring ON)** | **~$101** | EC2 c7g.large ($53) + EBS 60GB ($4.80) + NAT Gateway ($34) + CloudWatch ($4) + Bedrock Nova 2 Lite ($5.55). Traffic via NAT Gateway to AWS public endpoints (still encrypted via TLS). SSM-only access. |
+| **Minimal (VPCe OFF, monitoring OFF)** | **~$97** | Above minus CloudWatch monitoring. Save ~$4/mo. Lose auto-recovery, health alarms, log shipping. |
 | **Private Network (VPCe ON, monitoring ON)** | **~$189** | Default + 6 interface VPC endpoints across 2 AZs (**$14.60/endpoint/mo × 6 = $87.60**): Bedrock Runtime, Bedrock Mantle, SSM, SSM Messages, EC2 Messages, CloudWatch Logs. S3 Gateway endpoint free. Add **~$88/mo** (includes data processing). **All Bedrock + SSM traffic stays on AWS private network (never touches internet).** |
 | **Public Access (VPCe OFF, no WAF)** | **~$124** | Default + ALB ($22.27) + CloudFront ($0.53). Add **$22.80/mo**. HTTPS via CloudFront, but CloudFront→ALB uses HTTP (not end-to-end TLS). No Layer 7 WAF. |
 | **Public + Private Network (VPCe ON, no WAF)** | **~$212** | Above + 6 VPC endpoints. Add **$111/mo** total. |
@@ -271,7 +270,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | t4g.small | $12 | 2 | 2GB | Graviton ARM | Personal (minimal), burstable |
 | **t4g.medium** | **$24.53** | **2** | **4GB** | **Graviton ARM** | **Best value (save $28.40/mo vs c7g.large)** |
 | t4g.large | $49 | 2 | 8GB | Graviton ARM | Medium teams, burstable |
-| **c7g.large** | **~$53** | **2** | **4GB** | **Graviton ARM** | **Default (compute-optimized for Node.js + Docker)** |
+| **c7g.large** | **$53** | **2** | **4GB** | **Graviton ARM** | **Default (compute-optimized for Node.js + Docker)** |
 | c7g.xlarge | $106 | 4 | 8GB | Graviton ARM | Heavy compute workloads |
 | **r7g.medium** | **$39.13** | **1** | **8GB** | **Graviton ARM** | **Memory-optimized (save $13.80/mo, good for plugins/embeddings)** |
 | r7g.large | $78 | 2 | 16GB | Graviton ARM | Heavy usage / many plugins |
@@ -286,7 +285,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | `OpenClawModel` | `global.amazon.nova-2-lite-v1:0` | Bedrock model ID - Nova 2 Lite offers best price-performance for everyday tasks. 10 models available: Nova 2 Lite, Claude Sonnet 4.5, Nova Pro, Claude Opus 4.6, Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4, DeepSeek R1, Llama 3.3 70B, Kimi K2.5 |
 | `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.10` / `2026.4.27` (auto-discovery, embeddings), or `latest` (not recommended for production) |
 | `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. **c7g = compute-optimized** (recommended, 2 vCPU for Node.js + Docker sandbox), **r7g/r6g = memory-optimized** (plugins, embeddings), **t4g = burstable** (cost-optimized). 14 ARM + 7 x86 instance types available |
-| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus ~$0.75/mo data processing. S3 Gateway endpoint always free). **Default OFF to minimize cost** — traffic goes via NAT Gateway to AWS public HTTPS endpoints instead (still encrypted via TLS, no security downside for most use cases). Enable only if compliance requires private network routing (adds **~$88/mo**). |
+| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus ~$0.75/mo data processing. S3 Gateway endpoint always free). **Default OFF to minimize cost**. Traffic goes via NAT Gateway to AWS public HTTPS endpoints instead (still encrypted via TLS, no security downside for most use cases). Enable only if compliance requires private network routing (adds **$88/mo**). |
 | `EnableMonitoring` | `true` | Enable CloudWatch monitoring, EC2 auto-recovery + reboot alarms, metrics (memory, disk, swap), and log shipping (~$4/mo). **Recommended ON** for production |
 | `EnableSandbox` | `true` | Install Docker for sandboxed command execution (recommended for group chats and untrusted code). Adds ~500MB disk usage |
 | `EnableDataProtection` | `false` | Retain both EBS volume and S3 bucket when stack is deleted (protects against accidental data loss). **Set to true for production** |

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | `EnableMonitoring` | `true` | Enable CloudWatch monitoring, health checks, auto-recovery, and log shipping (+~$4/mo) |
 | `EnableSandbox` | `true` | Install Docker for sandboxed execution (recommended for group chats) |
 | `EnableDataProtection` | `false` | Retain data volume when stack is deleted (protects against accidental data loss) |
-| `EnablePublicAccess` | `false` | Enable public access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only |
+| `EnablePublicAccess` | `false` | Enable public access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only. **⚠️ Security Note**: CloudFront → ALB connection uses HTTP (not HTTPS), meaning origin traffic is unencrypted. This is an accepted tradeoff for simplicity. For full end-to-end encryption, add ACM certificate + HTTPS ALB listener (see SECURITY.md). |
 | `EnableWAF` | `true` | Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS, rate limiting, ~$10/mo). **⚠️ IMPORTANT: WAF only works in us-east-1.** If you deploy in other regions (e.g., us-west-2, ap-northeast-1, eu-west-1), the WAF will be silently skipped and you won't get Layer 7 protection. Deploy in us-east-1 to enable WAF, or accept that other regions only get Shield Standard (Layer 3/4 DDoS protection). |
 | `AllowedCountries` | _(empty)_ | CloudFront geographic restrictions. Leave empty (default) to allow worldwide access, or specify comma-separated ISO 3166-1 alpha-2 country codes to restrict access to specific countries (e.g., `AU,US,GB,JP`) |
 

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Switch models with one CloudFormation parameter — no code changes:
 | EBS (30GB gp3 x2) | $4.80 | Required (root + data volumes) |
 | NAT Gateway | ~$34 | Required (EC2 in private subnet, includes ~40GB data) |
 | CloudWatch Monitoring | ~$4 | ✅ Disable to save ~$4/mo |
-| VPC Endpoints (6 interface) | ~$88 | ✅ Enable for private network (+~$88/mo) |
+| VPC Endpoints (6 interface) | ~$88 | ✅ Enable for private network (+$88/mo) |
 | ALB + CloudFront | $22.80 | ✅ Enable for public access (+$22.80/mo) |
-| AWS WAF | ~$10 | ✅ Only if deploy to us-east-1 (+~$10/mo) |
+| AWS WAF | ~$10 | ✅ Only if deploy to us-east-1 (+$10/mo) |
 | Bedrock (Nova 2 Lite, ~100 conv/day) | $5.55 | Pay-per-use (~6M input + 1.5M output tokens/mo) |
 | **Total (default: VPCe OFF, monitoring ON)** | **~$101/mo** | EC2 + NAT + CloudWatch + Bedrock |
 | **Total (minimal: VPCe OFF, monitoring OFF)** | **~$97/mo** | Save ~$4/mo by disabling CloudWatch |
@@ -287,7 +287,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.10` / `2026.4.27` (auto-discovery, embeddings), or `latest` (not recommended for production) |
 | `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. **c7g = compute-optimized** (recommended, 2 vCPU for Node.js + Docker sandbox), **r7g/r6g = memory-optimized** (plugins, embeddings), **t4g = burstable** (cost-optimized). 14 ARM + 7 x86 instance types available |
 | `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus ~$0.75/mo data processing. S3 Gateway endpoint always free). **Default OFF to minimize cost** — traffic goes via NAT Gateway to AWS public HTTPS endpoints instead (still encrypted via TLS, no security downside for most use cases). Enable only if compliance requires private network routing (adds **~$88/mo**). |
-| `EnableMonitoring` | `true` | Enable CloudWatch monitoring, EC2 auto-recovery + reboot alarms, metrics (memory, disk, swap), and log shipping (+~$4/mo). **Recommended ON** for production |
+| `EnableMonitoring` | `true` | Enable CloudWatch monitoring, EC2 auto-recovery + reboot alarms, metrics (memory, disk, swap), and log shipping (~$4/mo). **Recommended ON** for production |
 | `EnableSandbox` | `true` | Install Docker for sandboxed command execution (recommended for group chats and untrusted code). Adds ~500MB disk usage |
 | `EnableDataProtection` | `false` | Retain both EBS volume and S3 bucket when stack is deleted (protects against accidental data loss). **Set to true for production** |
 | `EnablePublicAccess` | `false` | Enable public HTTPS access via ALB + CloudFront (~$25/mo). When disabled, access via SSM Session Manager only (secure, no open ports). **⚠️ Security Note**: CloudFront → ALB connection uses HTTP (not HTTPS), meaning origin traffic is unencrypted. This is an accepted tradeoff for simplicity. For full end-to-end encryption, add ACM certificate + HTTPS ALB listener (see SECURITY.md). |
@@ -463,7 +463,7 @@ The stack includes multiple layers of self-healing (always enabled, no extra cos
 | **OS security patches** | Unattended-upgrades for security fixes | Daily |
 | **`openclaw doctor`** | Config validation and auto-repair post-install | At install |
 
-**With `EnableMonitoring=true` (default, +~$4/mo):**
+**With `EnableMonitoring=true` (default, +$4/mo):**
 
 | Layer | What it does |
 |-------|-------------|

--- a/README.md
+++ b/README.md
@@ -144,20 +144,21 @@ You (WhatsApp/Telegram/Discord)
 │  AWS Cloud                                  │
 │                                             │
 │  EC2 (OpenClaw)  ──IAM──▶  Bedrock         │
-│       │                   (Nova/Claude)     │
-│       │                                     │
-│  VPC Endpoints        CloudTrail            │
-│  (private network)    (audit logs)          │
+│   (public subnet)         (Nova/Claude)     │
+│        │                                    │
+│   Internet Gateway    CloudTrail            │
+│   (direct access)     (audit logs)          │
 └─────────────────────────────────────────────┘
   │
   ▼
 You (receive response)
 ```
 
-- **EC2**: Runs OpenClaw gateway (~1GB RAM, c7g.large recommended)
+- **EC2**: Runs OpenClaw gateway in public subnet (~1GB RAM, c7g.large recommended)
 - **Bedrock**: Model inference via IAM (no API keys)
 - **SSM**: Secure access, no public ports
-- **VPC Endpoints**: Private network to Bedrock (optional, +$29/mo)
+- **Internet Gateway**: Direct internet access (no NAT Gateway cost)
+- **VPC Endpoints**: Optional private network to Bedrock (+$88/mo for 6 interface endpoints, S3 Gateway free)
 - **CloudWatch**: Auto-recovery, health monitoring, log shipping (optional, +$4/mo)
 
 ---
@@ -191,20 +192,19 @@ Switch models with one CloudFormation parameter — no code changes:
 |-----------|------------------|----------|
 | EC2 (c7g.large, Graviton) | ~$53 | Default (2 vCPU, 4GB RAM) |
 | EBS (30GB gp3 x2) | $4.80 | Required (root + data volumes) |
-| NAT Gateway | ~$34 | Required (EC2 in private subnet, includes ~40GB data) |
 | CloudWatch Monitoring | ~$4 | ✅ Disable to save ~$4/mo |
-| VPC Endpoints (6 interface) | ~$88 | ✅ Enable for private network (+$88/mo) |
+| VPC Endpoints (6 interface) | ~$88 | ✅ Enable for private network (+$88/mo, S3 Gateway free) |
 | ALB + CloudFront | $22.80 | ✅ Enable for public access (+$22.80/mo) |
 | AWS WAF | ~$10 | ✅ Only if deploy to us-east-1 (+$10/mo) |
 | Bedrock (Nova 2 Lite, ~100 conv/day) | $5.55 | Pay-per-use (~6M input + 1.5M output tokens/mo) |
-| **Total (default: VPCe OFF, monitoring ON)** | **~$101/mo** | EC2 + NAT + CloudWatch + Bedrock |
-| **Total (minimal: VPCe OFF, monitoring OFF)** | **~$97/mo** | Save ~$4/mo by disabling CloudWatch |
-| **Total (VPC Endpoints ON)** | **~$189/mo** | Add ~$88/mo for 6 interface endpoints across 2 AZs |
-| **Total (public access, no WAF)** | **~$124/mo** | Add $22.80/mo (ALB + CloudFront) |
-| **Total (public + VPCe, no WAF)** | **~$212/mo** | Add $111/mo (VPCe + public access) |
-| **Total (full security: public + VPCe + WAF, us-east-1)** | **~$222/mo** | Add $121/mo (full security stack) |
+| **Total (default: VPCe OFF, monitoring ON)** | **~$67/mo** | EC2 + CloudWatch + Bedrock (saves $34/mo, no NAT) |
+| **Total (minimal: VPCe OFF, monitoring OFF)** | **~$63/mo** | Save ~$4/mo by disabling CloudWatch (saves $38/mo vs old default) |
+| **Total (VPC Endpoints ON)** | **~$155/mo** | Add ~$88/mo for 6 interface endpoints across 2 AZs (S3 Gateway free) |
+| **Total (public access, no WAF)** | **~$90/mo** | Add $22.80/mo (ALB + CloudFront) |
+| **Total (public + VPCe, no WAF)** | **~$178/mo** | Add $111/mo (VPCe + public access) |
+| **Total (full security: public + VPCe + WAF, us-east-1)** | **~$188/mo** | Add $121/mo (full security stack) |
 
-> **Cost optimization**: Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) instead of c7g.large to save ~$30/mo. Enable VPC Endpoints only if you need private network routing (adds ~$88/mo).
+> **Cost optimization**: Use `t4g.medium` ($24/mo) or `r7g.medium` ($30/mo, 8GB RAM) instead of c7g.large to save ~$30/mo. Enable VPC Endpoints only if you need private network routing (adds ~$88/mo for 6 interface endpoints). **NAT Gateway removed** — saves $34/mo vs previous architecture.
 
 **Always included at no extra cost:**
 - 2GB swap (prevents OOM crashes)
@@ -213,7 +213,7 @@ Switch models with one CloudFormation parameter — no code changes:
 - IMDSv2 enforcement (HttpTokens: required, no v1 fallback)
 - `openclaw doctor --fix` post-install validation
 - systemd memory limits (graceful restart before OOM at 80% memory)
-- NAT Gateway (required for EC2 in private subnet, included in base cost)
+- Internet Gateway access (direct outbound connectivity, no NAT Gateway cost)
 - Node.js 22.22.0 pinned (prevents breakage from bad releases)
 - S3 Gateway VPC Endpoint (free, no hourly charge)
 
@@ -221,26 +221,27 @@ Switch models with one CloudFormation parameter — no code changes:
 - All costs based on **AWS Official Pricing API** for **us-west-2** (accessed May 2026)
 - EC2 c7g.large: **$0.0725/hour** = **~$53/month** (verified via AWS Pricing API)
 - VPC Interface Endpoints: **$0.01/hour/AZ** × 2 AZs = **$14.60/month per endpoint**
-- NAT Gateway: **$0.045/hour** = **$32.85/month** + **$0.045/GB** data processing (~$1.80/mo)
+- **NAT Gateway removed**: Saves **$32.85/hour** + **~$1.80 data processing** = **~$34/month**
 
 ### Cost Breakdown by Configuration
 
 | Configuration | Monthly Cost | What You Get |
 |--------------|-------------|--------------|
-| **Default (VPCe OFF, monitoring ON)** | **~$101** | EC2 c7g.large ($53) + EBS 60GB ($4.80) + NAT Gateway ($34) + CloudWatch ($4) + Bedrock Nova 2 Lite ($5.55). Traffic via NAT Gateway to AWS public endpoints (still encrypted via TLS). SSM-only access. |
-| **Minimal (VPCe OFF, monitoring OFF)** | **~$97** | Above minus CloudWatch monitoring. Save ~$4/mo. Lose auto-recovery, health alarms, log shipping. |
-| **Private Network (VPCe ON, monitoring ON)** | **~$189** | Default + 6 interface VPC endpoints across 2 AZs (**$14.60/endpoint/mo × 6 = $87.60**): Bedrock Runtime, Bedrock Mantle, SSM, SSM Messages, EC2 Messages, CloudWatch Logs. S3 Gateway endpoint free. Add **~$88/mo** (includes data processing). **All Bedrock + SSM traffic stays on AWS private network (never touches internet).** |
-| **Public Access (VPCe OFF, no WAF)** | **~$124** | Default + ALB ($22.27) + CloudFront ($0.53). Add **$22.80/mo**. HTTPS via CloudFront, but CloudFront→ALB uses HTTP (not end-to-end TLS). No Layer 7 WAF. |
-| **Public + Private Network (VPCe ON, no WAF)** | **~$212** | Above + 6 VPC endpoints. Add **$111/mo** total. |
-| **Full Security (public + VPCe + WAF, us-east-1 only)** | **~$222** | Above + AWS WAF (~$10): Web ACL + 5 managed rules (SQL injection, XSS, bad inputs, Linux protection, rate limiting 1000 req/5min). Add **$121/mo** total. ⚠️ **WAF only works in us-east-1** — other regions silently skip WAF (no Layer 7 protection, only Shield Standard Layer 3/4). |
+| **Default (VPCe OFF, monitoring ON)** | **~$67** | EC2 c7g.large ($53) + EBS 60GB ($4.80) + CloudWatch ($4) + Bedrock Nova 2 Lite ($5.55). Traffic via Internet Gateway to AWS public endpoints (TLS encrypted). SSM-only access. **Saves $34/mo** (no NAT Gateway). |
+| **Minimal (VPCe OFF, monitoring OFF)** | **~$63** | Above minus CloudWatch monitoring. Save ~$4/mo. Lose auto-recovery, health alarms, log shipping. **Saves $38/mo vs old architecture**. |
+| **Private Network (VPCe ON, monitoring ON)** | **~$155** | Default + 6 interface VPC endpoints across 2 AZs (**$14.60/endpoint/mo × 6 = $87.60**): Bedrock Runtime, Bedrock Mantle (conditional), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. S3 Gateway endpoint free. Add **~$88/mo** (includes data processing). **All AWS API traffic stays on private network (never touches internet).** |
+| **Public Access (VPCe OFF, no WAF)** | **~$90** | Default + ALB ($22.27) + CloudFront ($0.53). Add **$22.80/mo**. HTTPS via CloudFront, but CloudFront→ALB uses HTTP (not end-to-end TLS). No Layer 7 WAF. |
+| **Public + Private Network (VPCe ON, no WAF)** | **~$178** | Above + 6 VPC endpoints. Add **$111/mo** total. |
+| **Full Security (public + VPCe + WAF, us-east-1 only)** | **~$188** | Above + AWS WAF (~$10): Web ACL + 5 managed rules (SQL injection, XSS, bad inputs, Linux protection, rate limiting 1000 req/5min). Add **$121/mo** total. ⚠️ **WAF only works in us-east-1** — other regions silently skip WAF (no Layer 7 protection, only Shield Standard Layer 3/4). |
 
 ### Save Money
 
 - **Use Nova 2 Lite instead of Claude** → 90% cheaper inference ($0.30 vs $3-15 per 1M input tokens). **Already default** ✅
 - **Use Graviton (ARM) instead of x86** → 20-40% cheaper EC2. c7g.large (~$53/mo) vs r5.large x86 ($92/mo). **Already default** ✅
+- **No NAT Gateway** → **Saves $34/mo** vs previous architecture. Instance in public subnet with direct Internet Gateway access. **New default** ✅
 - **Use smaller instance type** → **t4g.medium** ($24.53/mo, 4GB RAM) **saves $28.40/mo** (54% cheaper) vs c7g.large. Trade-off: Less CPU for Docker sandbox. Good for light usage (<10 users).
 - **Use r7g.medium** → $39.13/mo (8GB RAM) **saves $13.80/mo** (26% cheaper) vs c7g.large. More memory for plugins/embeddings, but only 1 vCPU.
-- **Default config (VPCe OFF)** → **saves ~$88/mo** vs private network. Traffic goes via NAT Gateway to AWS public endpoints (still encrypted via TLS). **Best cost/benefit ratio for most use cases.** ✅
+- **Default config (VPCe OFF)** → **saves ~$88/mo** vs private network. Traffic goes via Internet Gateway to AWS public endpoints (TLS encrypted). **Best cost/benefit ratio for most use cases.** ✅
 - **Skip public access** (`EnablePublicAccess=false`) → **saves $22.80/mo** (no ALB + CloudFront). Use SSM Session Manager only. **Already default** ✅
 - **Disable monitoring** (`EnableMonitoring=false`) → **saves ~$4/mo** (lose auto-recovery alarms, health metrics, log shipping to CloudWatch). Not recommended for production.
 - **AWS Savings Plans** → **30-40% off EC2** for 1-3 year commitment. c7g.large: ~$53/mo → **~$31.76-37.05/mo** (save $15-21/mo). Must commit to instance family (c7g). Best for long-term deployments.
@@ -250,14 +251,15 @@ Switch models with one CloudFormation parameter — no code changes:
 | Option | Cost | What you get |
 |--------|------|-------------|
 | ChatGPT Plus | $20/person/month | Single user, no integrations, web UI only |
-| **This project (1 user)** | **$101/month** | 5x more expensive, but full control + integrations |
-| **This project (5 users)** | **$20.20/person/month** | Break-even with ChatGPT, multi-user, WhatsApp/Telegram/Discord/Slack |
-| **This project (10 users)** | **$10.10/person/month** | 50% cheaper, economy of scale |
-| **This project (20 users)** | **$5.05/person/month** | 75% cheaper, way more features |
-| **This project (50 users)** | **$2.02/person/month** | 90% cheaper, enterprise scale |
+| **This project (1 user)** | **$67/month** | 3.4x more expensive, but full control + integrations |
+| **This project (3 users)** | **$22.33/person/month** | Close to ChatGPT, multi-user, WhatsApp/Telegram/Discord/Slack |
+| **This project (5 users)** | **$13.40/person/month** | 33% cheaper, economy of scale |
+| **This project (10 users)** | **$6.70/person/month** | 67% cheaper, way more features |
+| **This project (20 users)** | **$3.35/person/month** | 83% cheaper, enterprise scale |
+| **This project (50 users)** | **$1.34/person/month** | 93% cheaper, large organization |
 | Local Mac Mini | $0 server + $20-30 API | Hardware cost, manage yourself, electricity cost |
 
-**Break-even point: ~5 users** (same cost as ChatGPT Plus)
+**Break-even point: ~3-4 users** (same cost as ChatGPT Plus) — **improved from 5 users after NAT Gateway removal**
 
 ---
 
@@ -285,7 +287,7 @@ Switch models with one CloudFormation parameter — no code changes:
 | `OpenClawModel` | `global.amazon.nova-2-lite-v1:0` | Bedrock model ID - Nova 2 Lite offers best price-performance for everyday tasks. 10 models available: Nova 2 Lite, Claude Sonnet 4.5, Nova Pro, Claude Opus 4.6, Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4, DeepSeek R1, Llama 3.3 70B, Kimi K2.5 |
 | `OpenClawVersion` | `2026.4.27` | OpenClaw version. `2026.3.24` (no model approval needed, WeChat compatible), `2026.4.5` / `2026.4.10` / `2026.4.27` (auto-discovery, embeddings), or `latest` (not recommended for production) |
 | `InstanceType` | `c7g.large` | EC2 instance type. Graviton (ARM) recommended. **c7g = compute-optimized** (recommended, 2 vCPU for Node.js + Docker sandbox), **r7g/r6g = memory-optimized** (plugins, embeddings), **t4g = burstable** (cost-optimized). 14 ARM + 7 x86 instance types available |
-| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus ~$0.75/mo data processing. S3 Gateway endpoint always free). **Default OFF to minimize cost**. Traffic goes via NAT Gateway to AWS public HTTPS endpoints instead (still encrypted via TLS, no security downside for most use cases). Enable only if compliance requires private network routing (adds **$88/mo**). |
+| `CreateVPCEndpoints` | `false` | Create VPC endpoints for private network access (**~$88/mo** for 6 interface endpoints across 2 AZs: Bedrock Runtime, Bedrock Mantle (conditional on region), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. Each endpoint: **$0.01/hour/AZ × 2 AZs × 730 hours = $14.60/mo**. Plus data processing charges. S3 Gateway endpoint free). **Default OFF to minimize cost**. Traffic goes via Internet Gateway to AWS public HTTPS endpoints instead (TLS encrypted, no security downside for most use cases). Enable only if compliance requires private network routing (adds **~$88/mo**). |
 | `EnableMonitoring` | `true` | Enable CloudWatch monitoring, EC2 auto-recovery + reboot alarms, metrics (memory, disk, swap), and log shipping (~$4/mo). **Recommended ON** for production |
 | `EnableSandbox` | `true` | Install Docker for sandboxed command execution (recommended for group chats and untrusted code). Adds ~500MB disk usage |
 | `EnableDataProtection` | `false` | Retain both EBS volume and S3 bucket when stack is deleted (protects against accidental data loss). **Set to true for production** |
@@ -425,9 +427,9 @@ Uses SiliconFlow (DeepSeek, Qwen, GLM) instead of Bedrock. Requires a SiliconFlo
 | **Supply-chain protection** | Docker via GPG-signed repos, NVM via download-then-execute (no `curl \| sh`), npm registry hardcoded |
 | **Docker Sandbox** | Isolates code execution in group chats (prevents host compromise) |
 | **CloudTrail** | Every Bedrock API call audited (who, when, what model, what input/output) |
-| **Private subnet + NAT** | EC2 in private subnet, no public IP, outbound via NAT Gateway |
+| **Public subnet (no public IP)** | EC2 in public subnet without public IP, outbound via Internet Gateway |
 | **Security groups** | Minimal ingress (ALB only if public access enabled), full egress |
-| **Network ACLs** | Stateless firewall on private subnets (HTTPS, DNS, ephemeral only) |
+| **Network ACLs** | Stateless firewall on VPC endpoint subnets (conditional, HTTPS + ephemeral only) |
 
 ### ⚠️ WAF Regional Limitation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,10 +44,10 @@ The CloudFormation template implements defense-in-depth with the following layer
 
 ### Private Access (SSM Session Manager Only)
 When `EnablePublicAccess=false` (default):
-1. **EC2 in private subnet** (no public IP)
-2. **NAT Gateway** for controlled outbound internet access
+1. **EC2 in public subnet** (no public IP assigned)
+2. **Internet Gateway** for direct outbound internet access (TLS encrypted to AWS endpoints)
 3. **SSM Session Manager** access only (no SSH required)
-4. **VPC endpoints** (optional, keeps AWS API traffic private)
+4. **VPC endpoints** (optional, keeps AWS API traffic on private network)
 5. **IMDSv2 enforcement** (prevents SSRF attacks)
 6. **EBS encryption** at rest (AWS managed keys)
 7. **S3 encryption** at rest (AES256)
@@ -64,6 +64,7 @@ When `EnablePublicAccess=true`, adds:
 6. **HTTPS enforcement** (CloudFront viewer side)
 7. **Geographic restrictions** (optional, via `AllowedCountries` parameter)
 8. ⚠️ **HTTP-only origin** (CloudFront → ALB uses unencrypted HTTP)
+9. **EC2 in public subnet** (for ALB target registration, no public IP assigned)
 
 ## Security Features
 
@@ -115,7 +116,7 @@ AllowedSSHCIDR: 127.0.0.1/32  # Disables SSH
 - ✅ Compliance-friendly (HIPAA, SOC2)
 - ✅ Reduced attack surface
 
-**Cost**: ~$22/month for 3 endpoints
+**Cost**: ~$88/month for 6 interface endpoints across 2 AZs (S3 Gateway endpoint free)
 
 ### 4. Docker Sandbox
 
@@ -151,7 +152,7 @@ When `EnablePublicAccess=true`, the deployment exposes OpenClaw via CloudFront +
 - ✅ AWS WAF protection (SQL injection, XSS, rate limiting)
 - ✅ Custom header validation (CloudFront → ALB, secret AWS::StackId)
 - ✅ CloudFront managed prefix list (only CloudFront IPs can reach ALB)
-- ✅ EC2 in private subnet (no direct internet access)
+- ✅ EC2 in public subnet (no public IP assigned, no direct internet inbound access)
 - ⚠️  **HTTP-only origin** (CloudFront → ALB uses unencrypted HTTP)
 
 **Known Limitation**: The CloudFront → ALB connection uses HTTP (port 80), not HTTPS. This means traffic between CloudFront edge locations and the ALB traverses the AWS network **unencrypted**.
@@ -159,7 +160,7 @@ When `EnablePublicAccess=true`, the deployment exposes OpenClaw via CloudFront +
 **Risk Assessment**:
 - Traffic mostly stays on AWS backbone (private network between CloudFront PoPs and ALB)
 - Custom header secret prevents direct ALB access (bypassing CloudFront)
-- EC2 instance is in private subnet (no public IP)
+- EC2 instance is in public subnet but has no public IP assigned (no direct internet inbound access)
 - This is an **accepted tradeoff** for deployment simplicity (no domain/ACM certificate required)
 
 **Mitigation** (if end-to-end encryption is required):
@@ -175,7 +176,7 @@ User (HTTPS encrypted)
   → CloudFront Edge Location (TLS termination)
   → [AWS Backbone - HTTP plaintext]
   → ALB in VPC (port 80)
-  → EC2 in private subnet (port 18789)
+  → EC2 in public subnet (port 18789, no public IP)
 ```
 
 For personal AI assistant deployments, the HTTP-only origin is acceptable. For production/enterprise use cases requiring full end-to-end encryption, implement the HTTPS ALB listener mitigation above.
@@ -205,11 +206,11 @@ This template implements the following AWS security best practices:
 - ⚠️ **CloudFront origin**: HTTP only (see section 6 above for details)
 
 ### 4. Network Isolation
-- ✅ **Private subnet**: EC2 instance has no public IP (`AssociatePublicIpAddress: false`)
-- ✅ **Security groups**: Deny-by-default, allow only required ports
-- ✅ **Network ACLs**: Stateless firewall on private subnet (HTTPS, DNS, ephemeral ports only)
-- ✅ **NAT Gateway**: Single controlled egress point for internet access
-- ✅ **VPC endpoints** (optional): Keep AWS API traffic off public internet
+- ✅ **Public subnet without public IP**: EC2 instance has no public IP (`AssociatePublicIpAddress: false`)
+- ✅ **Security groups**: Deny-by-default, allow only required ports (ALB ingress when public access enabled)
+- ✅ **Network ACLs**: Stateless firewall on VPC endpoint subnets (conditional, HTTPS + ephemeral only)
+- ✅ **Internet Gateway**: Direct outbound access to internet (TLS encrypted AWS endpoints)
+- ✅ **VPC endpoints** (optional): Keep AWS API traffic on private network (6 interface + 1 gateway)
 
 ### 5. Instance Metadata Security (IMDSv2)
 - ✅ **IMDSv2 enforced**: `HttpTokens: required` prevents SSRF attacks
@@ -383,16 +384,16 @@ systemctl --user restart clawdbot-gateway
 
 - Use `t4g.small` instance (Graviton, cost-effective)
 - Use Nova 2 Lite model (cheapest)
-- Disable VPC endpoints (save $22/month)
-- Allow SSH from your IP only
+- Disable VPC endpoints (save $88/month, traffic via Internet Gateway to public AWS endpoints)
+- Use SSM Session Manager only (no SSH needed)
 - Enable sandbox mode
 
 ### For Production
 
 - Use `t4g.medium` or larger (Graviton recommended)
 - Use Nova Pro or Claude models (better performance)
-- **Enable VPC endpoints** (required for security)
-- **Disable SSH** (`AllowedSSHCIDR: 127.0.0.1/32`)
+- **Enable VPC endpoints** (optional, adds $88/mo for private network routing)
+- **Use SSM Session Manager only** (no SSH access needed)
 - Enable sandbox mode
 - Set up CloudWatch alarms
 - Enable AWS Config rules
@@ -401,8 +402,8 @@ systemctl --user restart clawdbot-gateway
 ### For Compliance (HIPAA, PCI-DSS)
 
 - **Must use Graviton or x86 instances in compliant regions**
-- **Must enable VPC endpoints**
-- **Must disable SSH**
+- **Must enable VPC endpoints** (keeps all AWS API traffic on private network)
+- **Use SSM Session Manager only** (no SSH access)
 - Enable CloudTrail
 - Enable VPC Flow Logs
 - Encrypt EBS volumes (enabled by default)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,33 @@ aws ssm start-session \
 
 This deployment follows AWS security best practices and provides multiple layers of protection.
 
+## Security Architecture Summary
+
+The CloudFormation template implements defense-in-depth with the following layers:
+
+### Private Access (SSM Session Manager Only)
+When `EnablePublicAccess=false` (default):
+1. **EC2 in private subnet** (no public IP)
+2. **NAT Gateway** for controlled outbound internet access
+3. **SSM Session Manager** access only (no SSH required)
+4. **VPC endpoints** (optional, keeps AWS API traffic private)
+5. **IMDSv2 enforcement** (prevents SSRF attacks)
+6. **EBS encryption** at rest (AWS managed keys)
+7. **S3 encryption** at rest (AES256)
+8. **IAM role-based authentication** (no API keys)
+9. **Docker sandbox** for exec isolation
+
+### Public Access (CloudFront + ALB)
+When `EnablePublicAccess=true`, adds:
+1. **AWS Shield Standard** (automatic DDoS protection - Layer 3/4)
+2. **AWS WAF** (only in us-east-1) - SQL injection, XSS, rate limiting, bad inputs
+3. **CloudFront managed prefix list** (only CloudFront IPs can reach ALB)
+4. **Custom header validation** (CloudFront → ALB, secret AWS::StackId)
+5. **Direct ALB access blocked** (returns 403 without header)
+6. **HTTPS enforcement** (CloudFront viewer side)
+7. **Geographic restrictions** (optional, via `AllowedCountries` parameter)
+8. ⚠️ **HTTP-only origin** (CloudFront → ALB uses unencrypted HTTP)
+
 ## Security Features
 
 ### 1. IAM Role-Based Authentication
@@ -114,6 +141,125 @@ AllowedSSHCIDR: 127.0.0.1/32  # Disables SSH
 When running agents for multiple users, compute isolation prevents one agent from observing or interfering with another. AgentCore and ECS Fargate provide hardware-level isolation via Firecracker microVMs (same technology as AWS Lambda). EKS deployments can enable Kata Containers for equivalent isolation.
 
 For detailed runtime comparison, see [docs/DEPLOYMENT_EKS.md](docs/DEPLOYMENT_EKS.md).
+
+### 6. Public Access Security (CloudFront + ALB)
+
+When `EnablePublicAccess=true`, the deployment exposes OpenClaw via CloudFront + ALB:
+
+**Security Layers**:
+- ✅ CloudFront HTTPS enforcement (viewer → CloudFront encrypted)
+- ✅ AWS WAF protection (SQL injection, XSS, rate limiting)
+- ✅ Custom header validation (CloudFront → ALB, secret AWS::StackId)
+- ✅ CloudFront managed prefix list (only CloudFront IPs can reach ALB)
+- ✅ EC2 in private subnet (no direct internet access)
+- ⚠️  **HTTP-only origin** (CloudFront → ALB uses unencrypted HTTP)
+
+**Known Limitation**: The CloudFront → ALB connection uses HTTP (port 80), not HTTPS. This means traffic between CloudFront edge locations and the ALB traverses the AWS network **unencrypted**.
+
+**Risk Assessment**:
+- Traffic mostly stays on AWS backbone (private network between CloudFront PoPs and ALB)
+- Custom header secret prevents direct ALB access (bypassing CloudFront)
+- EC2 instance is in private subnet (no public IP)
+- This is an **accepted tradeoff** for deployment simplicity (no domain/ACM certificate required)
+
+**Mitigation** (if end-to-end encryption is required):
+1. Obtain a domain name (e.g., via Route 53)
+2. Create ACM certificate for the domain
+3. Add HTTPS listener on ALB (port 443)
+4. Update CloudFront origin to use HTTPS protocol policy
+5. Validate certificate on ALB
+
+**Traffic Flow**:
+```
+User (HTTPS encrypted)
+  → CloudFront Edge Location (TLS termination)
+  → [AWS Backbone - HTTP plaintext]
+  → ALB in VPC (port 80)
+  → EC2 in private subnet (port 18789)
+```
+
+For personal AI assistant deployments, the HTTP-only origin is acceptable. For production/enterprise use cases requiring full end-to-end encryption, implement the HTTPS ALB listener mitigation above.
+
+## CloudFormation Security Best Practices
+
+This template implements the following AWS security best practices:
+
+### 1. Least Privilege IAM Policies
+- ✅ Instance role grants **only** required Bedrock actions (`InvokeModel`, `InvokeModelWithResponseStream`, `ListFoundationModels`)
+- ✅ SSM parameter access scoped to `/openclaw/${StackName}/*` only
+- ✅ S3 bucket access scoped to specific bucket ARN only
+- ✅ CloudWatch logs scoped to `/openclaw/*` log groups only
+- ✅ No wildcard `Resource: "*"` except where AWS service requires it (e.g., `ec2:DescribeTags`)
+
+### 2. Encryption at Rest
+- ✅ **EBS volumes**: Encrypted with AWS managed keys (`Encrypted: true`)
+- ✅ **S3 bucket**: Server-side encryption with AES256 (`SSEAlgorithm: AES256`)
+- ✅ **SSM parameters**: Gateway token stored as `SecureString` type (encrypted with KMS)
+- ✅ **CloudWatch Logs**: Automatically encrypted by AWS
+
+### 3. Encryption in Transit
+- ✅ **Bedrock API**: HTTPS only (enforced by AWS SDK)
+- ✅ **SSM Session Manager**: TLS encrypted session tunnel
+- ✅ **VPC endpoints**: HTTPS only (TLS 1.2+)
+- ✅ **CloudFront viewer**: HTTPS enforced (`redirect-to-https` policy)
+- ⚠️ **CloudFront origin**: HTTP only (see section 6 above for details)
+
+### 4. Network Isolation
+- ✅ **Private subnet**: EC2 instance has no public IP (`AssociatePublicIpAddress: false`)
+- ✅ **Security groups**: Deny-by-default, allow only required ports
+- ✅ **Network ACLs**: Stateless firewall on private subnet (HTTPS, DNS, ephemeral ports only)
+- ✅ **NAT Gateway**: Single controlled egress point for internet access
+- ✅ **VPC endpoints** (optional): Keep AWS API traffic off public internet
+
+### 5. Instance Metadata Security (IMDSv2)
+- ✅ **IMDSv2 enforced**: `HttpTokens: required` prevents SSRF attacks
+- ✅ **Hop limit**: `HttpPutResponseHopLimit: 2` allows Docker containers to access metadata
+- ✅ **Token-based authentication**: Prevents IP spoofing and replay attacks
+
+### 6. S3 Bucket Security
+- ✅ **Block public access**: All four settings enabled (`BlockPublicAcls`, `BlockPublicPolicy`, `IgnorePublicAcls`, `RestrictPublicBuckets`)
+- ✅ **Versioning enabled**: Protects against accidental deletion/overwrite
+- ✅ **Lifecycle policy**: Auto-delete old versions after 30 days (cost optimization)
+- ✅ **Encryption**: AES256 server-side encryption
+- ✅ **Deletion policy**: Configurable via `EnableDataProtection` parameter
+
+### 7. Secrets Management
+- ✅ **Gateway token**: Generated with `openssl rand -hex 24` (192 bits entropy)
+- ✅ **Token storage**: SSM Parameter Store SecureString (KMS encrypted)
+- ✅ **Custom header**: Uses AWS::StackId (UUID, unpredictable)
+- ✅ **No hardcoded secrets**: All secrets generated at stack creation time
+
+### 8. Monitoring & Logging
+- ✅ **CloudTrail**: Bedrock API calls automatically logged (account-level)
+- ✅ **CloudWatch Logs**: Setup logs, health check logs shipped to CloudWatch
+- ✅ **CloudWatch Alarms**: Auto-recovery on system status check failure, reboot on instance check failure
+- ✅ **Health checks**: Cron job checks gateway port + HTTP response every 5 minutes
+
+### 9. Defense in Depth (CloudFront + ALB)
+- ✅ **AWS Shield Standard**: Automatic DDoS protection (Layer 3/4)
+- ✅ **AWS WAF** (us-east-1 only): SQL injection, XSS, rate limiting (1000 req/5min/IP), bad inputs
+- ✅ **Custom header validation**: CloudFront sends `X-Custom-Header: ${AWS::StackId}`, ALB validates
+- ✅ **CloudFront managed prefix list**: ALB security group only allows CloudFront IP ranges
+- ✅ **Default deny**: ALB listener returns 403 for requests without custom header
+- ✅ **Geographic restrictions** (optional): `AllowedCountries` parameter restricts CloudFront access by country
+
+### 10. Patch Management
+- ✅ **Latest Ubuntu 24.04 LTS**: Resolved dynamically via SSM Parameter Store
+- ✅ **Unattended security upgrades**: Automatically configured during setup
+- ✅ **Package updates**: `apt-get upgrade -y` during initial setup
+- ✅ **OpenClaw updates**: Version pinned via `OpenClawVersion` parameter (controlled upgrades)
+
+### 11. Secure Defaults
+- ✅ **VPC endpoints disabled by default**: Saves cost, users opt-in for production
+- ✅ **Public access disabled by default**: SSM Session Manager only, users opt-in for internet exposure
+- ✅ **WAF enabled by default** (when in us-east-1): Protection-first approach
+- ✅ **Data protection disabled by default**: Prevents orphaned resources during testing
+- ✅ **Monitoring enabled by default**: CloudWatch alarms + logs shipped automatically
+
+### 12. Resource Tagging
+- ✅ **All resources tagged**: `Name` tags for easy identification
+- ✅ **Stack name prefix**: All resources include `${AWS::StackName}` for multi-stack support
+- ✅ **Cost allocation**: Tags enable cost tracking per stack
 
 ## Security Checklist
 

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -65,7 +65,7 @@ Parameters:
 
   CreateVPCEndpoints:
     Type: String
-    Default: "true"
+    Default: "false"
     Description: "Create VPC endpoints for private network access to Bedrock and SSM"
     AllowedValues:
       - "true"
@@ -120,8 +120,8 @@ Parameters:
 
   AllowedCountries:
     Type: CommaDelimitedList
-    Default: "AU"
-    Description: "IMPORTANT: Default restricts CloudFront access to Australia (AU) only. Change before deployment to add other countries (e.g., AU,US,CN,GB,JP) or leave empty to allow all countries. ISO 3166-1 alpha-2 codes."
+    Default: ""
+    Description: "Optional: Restrict CloudFront access to specific countries using ISO 3166-1 alpha-2 codes (e.g., AU,US,GB,JP). Leave empty (default) to allow all countries worldwide."
 
 Conditions:
   CreateEndpoints: !Equals [!Ref CreateVPCEndpoints, "true"]
@@ -191,6 +191,45 @@ Mappings:
     r7g.medium: { Arch: "arm64" }
     r7g.large: { Arch: "arm64" }
     r7g.xlarge: { Arch: "arm64" }
+
+  # CloudFront Managed Prefix List IDs by Region
+  # AWS Global service: com.amazonaws.global.cloudfront.origin-facing
+  # Note: AWS China (cn-*) and GovCloud (us-gov-*) regions are separate partitions
+  # and do not have CloudFront service, so they are not included here.
+  CloudFrontPrefixListMap:
+    # US regions
+    us-east-1: { PrefixListId: "pl-3b927c52" }
+    us-east-2: { PrefixListId: "pl-b6a144df" }
+    us-west-1: { PrefixListId: "pl-4ea04527" }
+    us-west-2: { PrefixListId: "pl-82a045eb" }
+    # Asia Pacific regions
+    ap-south-1: { PrefixListId: "pl-9aa247f3" }
+    ap-south-2: { PrefixListId: "pl-02a34e6b" }
+    ap-northeast-1: { PrefixListId: "pl-58a04531" }
+    ap-northeast-2: { PrefixListId: "pl-22a6434b" }
+    ap-northeast-3: { PrefixListId: "pl-96a247ff" }
+    ap-southeast-1: { PrefixListId: "pl-31a34658" }
+    ap-southeast-2: { PrefixListId: "pl-b8a742d1" }
+    ap-southeast-3: { PrefixListId: "pl-1ea34677" }
+    ap-southeast-4: { PrefixListId: "pl-9aa344f3" }
+    # Canada regions
+    ca-central-1: { PrefixListId: "pl-38a64351" }
+    # Europe regions
+    eu-central-1: { PrefixListId: "pl-a3a144ca" }
+    eu-central-2: { PrefixListId: "pl-14a5467d" }
+    eu-west-1: { PrefixListId: "pl-4fa04526" }
+    eu-west-2: { PrefixListId: "pl-93a247fa" }
+    eu-west-3: { PrefixListId: "pl-75b1541c" }
+    eu-south-1: { PrefixListId: "pl-8fa045e6" }
+    eu-south-2: { PrefixListId: "pl-04a5466d" }
+    eu-north-1: { PrefixListId: "pl-fab65393" }
+    # South America regions
+    sa-east-1: { PrefixListId: "pl-5da64334" }
+    # Middle East and Africa regions
+    af-south-1: { PrefixListId: "pl-a9a045c0" }
+    me-south-1: { PrefixListId: "pl-17a3467e" }
+    me-central-1: { PrefixListId: "pl-a1a242c8" }
+    il-central-1: { PrefixListId: "pl-89a64be0" }
 
 
 Resources:
@@ -728,8 +767,8 @@ Resources:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          SourcePrefixListId: pl-82a045eb
-          Description: "HTTP from CloudFront managed prefix list"
+          SourcePrefixListId: !FindInMap [CloudFrontPrefixListMap, !Ref "AWS::Region", PrefixListId]
+          Description: "HTTP from CloudFront managed prefix list (com.amazonaws.global.cloudfront.origin-facing)"
       SecurityGroupEgress:
         - IpProtocol: -1
           CidrIp: "0.0.0.0/0"

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -628,36 +628,6 @@ Resources:
       SecurityGroupIds:
         - !Ref VPCEndpointSecurityGroup
 
-  # CloudFormation VPC Endpoint (for stack signaling)
-  CloudFormationVPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Condition: CreateEndpoints
-    Properties:
-      VpcId: !Ref OpenClawVPC
-      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.cloudformation'
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: true
-      SubnetIds:
-        - !Ref PrivateSubnet
-        - !Ref PrivateSubnet2
-      SecurityGroupIds:
-        - !Ref VPCEndpointSecurityGroup
-
-  # EC2 VPC Endpoint (for describe-tags API calls)
-  EC2VPCEndpoint:
-    Type: AWS::EC2::VPCEndpoint
-    Condition: CreateEndpoints
-    Properties:
-      VpcId: !Ref OpenClawVPC
-      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ec2'
-      VpcEndpointType: Interface
-      PrivateDnsEnabled: true
-      SubnetIds:
-        - !Ref PrivateSubnet
-        - !Ref PrivateSubnet2
-      SecurityGroupIds:
-        - !Ref VPCEndpointSecurityGroup
-
   # ==================== IAM Role ====================
   OpenClawInstanceRole:
     Type: AWS::IAM::Role
@@ -1908,17 +1878,10 @@ Outputs:
 
   CloudFrontURL:
     Condition: EnablePublic
-    Description: "PUBLIC ACCESS URL (HTTPS). Replace <token> with the value from the output 'GetToken'"
+    Description: "OpenClaw Public Access URL (HTTPS). Replace <token> with the value from the output 'GetToken'"
     Value: !Sub
       - "https://${Domain}/?token=<token>"
       - Domain: !GetAtt OpenClawCloudFrontDistribution.DomainName
-
-  ALBURL:
-    Condition: EnablePublic
-    Description: "ALB URL (HTTP) - Replace <token> with the value from the output 'GetToken'. Not secured, for testing/debugging only (bypasses CloudFront)."
-    Value: !Sub
-      - "http://${Domain}/?token=<token>"
-      - Domain: !GetAtt OpenClawALB.DNSName
 
   Step1InstallSSMPlugin:
     Condition: DisablePublic
@@ -1991,12 +1954,12 @@ Outputs:
 
   S3BucketNameRetained:
     Condition: ProtectData
-    Description: "S3 bucket name (retained on stack delete)"
+    Description: "S3 bucket name that interacts with OpenClaw (retained on stack delete)"
     Value: !Ref OpenClawS3BucketRetained
 
   S3BucketNameNotRetained:
     Condition: DeleteData
-    Description: "S3 bucket name (deleted with stack)"
+    Description: "S3 bucket name that interacts with OpenClaw (deleted with stack)"
     Value: !Ref OpenClawS3BucketNotRetained
 
   SecurityFeatures:

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -14,13 +14,11 @@ Metadata:
           - OpenClawModel
           - OpenClawVersion
           - InstanceType
-          - KeyPairName
       - Label:
           default: "Network Configuration"
         Parameters:
           - CreateVPCEndpoints
           - EnableMonitoring
-          - AllowedSSHCIDR
 
 Parameters:
   OpenClawModel:
@@ -65,16 +63,6 @@ Parameters:
       - "r5.large"
       - "r5.xlarge"
 
-  KeyPairName:
-    Type: String
-    Default: "none"
-    Description: "EC2 key pair for emergency SSH access (optional - set to 'none' to skip)"
-
-  AllowedSSHCIDR:
-    Type: String
-    Default: ""
-    Description: "CIDR for SSH access (optional - leave empty for no inbound rules. SSM Session Manager is used for access. If SSH is needed, set to your IP/32 - find your IP at checkip.amazonaws.com)"
-
   CreateVPCEndpoints:
     Type: String
     Default: "true"
@@ -90,12 +78,13 @@ Parameters:
 
   OpenClawVersion:
     Type: String
-    Default: "2026.3.24"
+    Default: "2026.4.27"
     AllowedValues:
       - "2026.3.24"
       - "2026.4.5"
+      - "2026.4.27"
       - "latest"
-    Description: "OpenClaw version. 2026.3.24 (default, no model approval needed, WeChat compatible). 2026.4.5+ (auto-discovery, embeddings)."
+    Description: "OpenClaw version. 2026.3.24 (no model approval needed, WeChat compatible). 2026.4.5+ (auto-discovery, embeddings)."
 
   EnableMonitoring:
     Type: String
@@ -113,12 +102,37 @@ Parameters:
       - "true"
       - "false"
 
+  EnablePublicAccess:
+    Type: String
+    Default: "false"
+    Description: "Enable public access via ALB + CloudFront"
+    AllowedValues:
+      - "true"
+      - "false"
+
+  EnableWAF:
+    Type: String
+    Default: "true"
+    Description: "Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS). WAF must be created in us-east-1."
+    AllowedValues:
+      - "true"
+      - "false"
+
+  AllowedCountries:
+    Type: CommaDelimitedList
+    Default: "AU"
+    Description: "IMPORTANT: Default restricts CloudFront access to Australia (AU) only. Change before deployment to add other countries (e.g., AU,US,CN,GB,JP) or leave empty to allow all countries. ISO 3166-1 alpha-2 codes."
+
 Conditions:
   CreateEndpoints: !Equals [!Ref CreateVPCEndpoints, "true"]
-  HasKeyPair: !Not [!Equals [!Ref KeyPairName, "none"]]
-  AllowSSH: !And
-    - !Not [!Equals [!Ref AllowedSSHCIDR, ""]]
-    - !Not [!Equals [!Ref KeyPairName, "none"]]
+  CreateWAF: !And
+    - !Equals [!Ref EnableWAF, "true"]
+    - !Equals [!Ref EnablePublicAccess, "true"]
+    - !Equals [!Ref "AWS::Region", "us-east-1"]
+  HasGeoRestriction: !Not
+    - !Equals
+      - !Join [",", !Ref AllowedCountries]
+      - ""
   # Bedrock Mantle supported regions: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html#bedrock-mantle-supported
   IsUsEast1: !Equals [ !Ref "AWS::Region", "us-east-1" ]
   IsUsEast2: !Equals [ !Ref "AWS::Region", "us-east-2" ]
@@ -147,11 +161,12 @@ Conditions:
       - Condition: IsEuSouth1
       - Condition: IsEuNorth1
       - Condition: IsSaEast1
-  CreateMantleEndpoint: !And [ Condition: CreateEndpoints, Condition: IsMantleSupportedRegion ]     
-  EnableDocker: !Equals [!Ref EnableSandbox, "true"]
+  CreateMantleEndpoint: !And [ Condition: CreateEndpoints, Condition: IsMantleSupportedRegion ]
   EnableCW: !Equals [!Ref EnableMonitoring, "true"]
   ProtectData: !Equals [!Ref EnableDataProtection, "true"]
   DeleteData: !Not [!Equals [!Ref EnableDataProtection, "true"]]
+  EnablePublic: !Equals [!Ref EnablePublicAccess, "true"]
+  DisablePublic: !Not [!Equals [!Ref EnablePublicAccess, "true"]]
 
 Mappings:
   ArchitectureMap:
@@ -211,6 +226,25 @@ Resources:
       VpcId: !Ref OpenClawVPC
       InternetGatewayId: !Ref OpenClawInternetGateway
 
+  # NAT Gateway for private subnet internet access
+  NATGatewayEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: AttachGateway
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-nat-eip"
+
+  NATGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NATGatewayEIP.AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-nat-gateway"
+
   PublicSubnet:
     Type: AWS::EC2::Subnet
     Properties:
@@ -220,7 +254,19 @@ Resources:
       AvailabilityZone: !Select [0, !GetAZs '']
       Tags:
         - Key: Name
-          Value: !Sub "${AWS::StackName}-public-subnet"
+          Value: !Sub "${AWS::StackName}-public-subnet-az1"
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Condition: EnablePublic
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      CidrBlock: "10.0.4.0/24"
+      MapPublicIpOnLaunch: true
+      AvailabilityZone: !Select [1, !GetAZs '']
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-subnet-az2"
 
   PrivateSubnet:
     Type: AWS::EC2::Subnet
@@ -264,6 +310,166 @@ Resources:
     Properties:
       SubnetId: !Ref PublicSubnet
       RouteTableId: !Ref PublicRouteTable
+
+  SubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: EnablePublic
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  # Private Route Table for private subnets
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-rtb"
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref NATGateway
+
+  PrivateSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: CreateEndpoints
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable
+
+  # ==================== Network ACLs for Private Subnet Security ====================
+  PrivateNetworkAcl:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-nacl"
+
+  # Inbound Rules
+  PrivateNetworkAclInboundHTTP:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 100
+      Protocol: 6
+      RuleAction: allow
+      CidrBlock: 10.0.0.0/16
+      PortRange:
+        From: 80
+        To: 80
+
+  PrivateNetworkAclInboundHTTPS:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 110
+      Protocol: 6
+      RuleAction: allow
+      CidrBlock: 10.0.0.0/16
+      PortRange:
+        From: 443
+        To: 443
+
+  PrivateNetworkAclInboundOpenClaw:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 120
+      Protocol: 6
+      RuleAction: allow
+      CidrBlock: 10.0.0.0/16
+      PortRange:
+        From: 18789
+        To: 18789
+
+  PrivateNetworkAclInboundEphemeral:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 130
+      Protocol: 6
+      RuleAction: allow
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 1024
+        To: 65535
+
+  # Outbound Rules - Restrictive (only HTTPS + DNS)
+  PrivateNetworkAclOutboundHTTPS:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 100
+      Protocol: 6
+      Egress: true
+      RuleAction: allow
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 443
+        To: 443
+
+  PrivateNetworkAclOutboundHTTP:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 110
+      Protocol: 6
+      Egress: true
+      RuleAction: allow
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 80
+        To: 80
+
+  PrivateNetworkAclOutboundDNS:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 120
+      Protocol: 17
+      Egress: true
+      RuleAction: allow
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 53
+        To: 53
+
+  PrivateNetworkAclOutboundEphemeral:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref PrivateNetworkAcl
+      RuleNumber: 130
+      Protocol: 6
+      Egress: true
+      RuleAction: allow
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 1024
+        To: 65535
+
+  PrivateSubnetNetworkAclAssociation:
+    Type: AWS::EC2::SubnetNetworkAclAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      NetworkAclId: !Ref PrivateNetworkAcl
+
+  PrivateSubnetNetworkAclAssociation2:
+    Type: AWS::EC2::SubnetNetworkAclAssociation
+    Condition: CreateEndpoints
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      NetworkAclId: !Ref PrivateNetworkAcl
 
   # VPC Endpoint Security Group
   VPCEndpointSecurityGroup:
@@ -355,6 +561,63 @@ Resources:
       SecurityGroupIds:
         - !Ref VPCEndpointSecurityGroup
 
+  # S3 Gateway VPC Endpoint (no additional cost, for S3 API access)
+  S3GatewayVPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Condition: CreateEndpoints
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
+      VpcEndpointType: Gateway
+      RouteTableIds:
+        - !Ref PublicRouteTable
+        - !Ref PrivateRouteTable
+
+  # CloudWatch Logs VPC Endpoint (for log shipping)
+  CloudWatchLogsVPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Condition: CreateEndpoints
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.logs'
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PrivateSubnet
+        - !Ref PrivateSubnet2
+      SecurityGroupIds:
+        - !Ref VPCEndpointSecurityGroup
+
+  # CloudFormation VPC Endpoint (for stack signaling)
+  CloudFormationVPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Condition: CreateEndpoints
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.cloudformation'
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PrivateSubnet
+        - !Ref PrivateSubnet2
+      SecurityGroupIds:
+        - !Ref VPCEndpointSecurityGroup
+
+  # EC2 VPC Endpoint (for describe-tags API calls)
+  EC2VPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Condition: CreateEndpoints
+    Properties:
+      VpcId: !Ref OpenClawVPC
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ec2'
+      VpcEndpointType: Interface
+      PrivateDnsEnabled: true
+      SubnetIds:
+        - !Ref PrivateSubnet
+        - !Ref PrivateSubnet2
+      SecurityGroupIds:
+        - !Ref VPCEndpointSecurityGroup
+
   # ==================== IAM Role ====================
   OpenClawInstanceRole:
     Type: AWS::IAM::Role
@@ -430,6 +693,20 @@ Resources:
                   - 'cloudformation:DescribeStackResource'
                   - 'cloudformation:SignalResource'
                 Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: S3BucketAccessPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:GetObject'
+                  - 's3:PutObject'
+                  - 's3:DeleteObject'
+                  - 's3:ListBucket'
+                  - 's3:GetBucketLocation'
+                Resource:
+                  - !GetAtt OpenClawS3Bucket.Arn
+                  - !Sub '${OpenClawS3Bucket.Arn}/*'
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-instance-role"
@@ -441,19 +718,38 @@ Resources:
         - !Ref OpenClawInstanceRole
 
   # ==================== Security Group ====================
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: EnablePublic
+    Properties:
+      GroupDescription: "ALB security group - CloudFront managed prefix list only"
+      VpcId: !Ref OpenClawVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: pl-82a045eb
+          Description: "HTTP from CloudFront managed prefix list"
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: "0.0.0.0/0"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-sg"
+
   OpenClawSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "OpenClaw instance security group"
+      GroupDescription: "OpenClaw instance security group - SSM Session Manager only (no SSH)"
       VpcId: !Ref OpenClawVPC
       SecurityGroupIngress:
         - !If
-          - AllowSSH
+          - EnablePublic
           - IpProtocol: tcp
-            FromPort: 22
-            ToPort: 22
-            CidrIp: !Ref AllowedSSHCIDR
-            Description: "SSH access (fallback)"
+            FromPort: 18789
+            ToPort: 18789
+            SourceSecurityGroupId: !Ref ALBSecurityGroup
+            Description: "OpenClaw from ALB"
           - !Ref AWS::NoValue
       SecurityGroupEgress:
         - IpProtocol: -1
@@ -461,6 +757,33 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-sg"
+
+  # ==================== S3 Bucket ====================
+  OpenClawS3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "openclaw-${AWS::StackName}-${AWS::AccountId}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldVersions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-data-bucket"
 
   # ==================== Data Volume ====================
   OpenClawDataVolumeRetained:
@@ -508,10 +831,12 @@ Resources:
                   "gateway": {
                     "mode": "local",
                     "port": 18789,
-                    "bind": "loopback",
+                    "bind": "BIND_ADDRESS_PLACEHOLDER",
+                    "trustedProxies": ["10.0.0.0/16"],
                     "controlUi": {
                       "enabled": true,
-                      "allowInsecureAuth": true
+                      "dangerouslyDisableDeviceAuth": true,
+                      "allowedOrigins": "ALLOWED_ORIGINS_PLACEHOLDER"
                     },
                     "auth": {
                       "mode": "token",
@@ -553,10 +878,12 @@ Resources:
                   "gateway": {
                     "mode": "local",
                     "port": 18789,
-                    "bind": "loopback",
+                    "bind": "BIND_ADDRESS_PLACEHOLDER",
+                    "trustedProxies": ["10.0.0.0/16"],
                     "controlUi": {
                       "enabled": true,
-                      "allowInsecureAuth": true
+                      "dangerouslyDisableDeviceAuth": true,
+                      "allowedOrigins": "ALLOWED_ORIGINS_PLACEHOLDER"
                     },
                     "auth": {
                       "mode": "token",
@@ -885,8 +1212,36 @@ Resources:
                     cp /opt/openclaw/openclaw-config-modern.json "$STATE_DIR/openclaw.json"
                   fi
                   chown ubuntu:ubuntu "$STATE_DIR/openclaw.json"
+
+                  # Configure bind address and allowed origins based on public access
+                  if [ "${EnablePublicAccess}" = "true" ]; then
+                    BIND_ADDRESS="0.0.0.0"
+                    echo "Public access enabled - binding to 0.0.0.0"
+
+                    # Get CloudFront domain from stack outputs
+                    CLOUDFRONT_DOMAIN=$(aws cloudformation describe-stacks \
+                      --stack-name "${AWS::StackName}" \
+                      --region "${AWS::Region}" \
+                      --query 'Stacks[0].Outputs[?OutputKey==`CloudFrontURL`].OutputValue' \
+                      --output text 2>/dev/null | grep -oP 'https://[^/]+' || echo "")
+
+                    if [ -n "$CLOUDFRONT_DOMAIN" ]; then
+                      ALLOWED_ORIGINS="[\"$CLOUDFRONT_DOMAIN\"]"
+                      echo "Configuring allowedOrigins: $ALLOWED_ORIGINS"
+                    else
+                      ALLOWED_ORIGINS="[]"
+                      echo "CloudFront domain not found, allowedOrigins will be empty"
+                    fi
+                  else
+                    BIND_ADDRESS="loopback"
+                    ALLOWED_ORIGINS="[]"
+                    echo "Private access only - binding to loopback"
+                  fi
+
+                  sed -i "s/BIND_ADDRESS_PLACEHOLDER/$BIND_ADDRESS/g" "$STATE_DIR/openclaw.json"
                   sed -i "s/GATEWAY_TOKEN_PLACEHOLDER/$GATEWAY_TOKEN/g" "$STATE_DIR/openclaw.json"
                   sed -i "s|MODEL_ID_PLACEHOLDER|${OpenClawModel}|g" "$STATE_DIR/openclaw.json"
+                  sed -i "s|\"ALLOWED_ORIGINS_PLACEHOLDER\"|$ALLOWED_ORIGINS|g" "$STATE_DIR/openclaw.json"
 
                   # Install and start gateway
                   for i in $(seq 1 15); do
@@ -904,6 +1259,17 @@ Resources:
                   export NVM_DIR="$HOME/.nvm"
                   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
                   openclaw gateway install || echo "Gateway install failed"
+
+                  # Fix systemd service to include OPENCLAW_STATE_DIR
+                  SERVICE_FILE="$HOME/.config/systemd/user/openclaw-gateway.service"
+                  if [ -f "$SERVICE_FILE" ]; then
+                    if ! grep -q "OPENCLAW_STATE_DIR" "$SERVICE_FILE"; then
+                      sed -i "/^Environment=OPENCLAW_GATEWAY_PORT/a Environment=OPENCLAW_STATE_DIR=$STATE_DIR" "$SERVICE_FILE"
+                      systemctl --user daemon-reload
+                      echo "Added OPENCLAW_STATE_DIR to systemd service"
+                    fi
+                  fi
+
                   systemctl --user start openclaw-gateway.service || { openclaw gateway & } || echo "Gateway start failed"
                   '
 
@@ -1107,7 +1473,7 @@ Resources:
                           "disk": { "measurement": ["disk_used_percent"], "resources": ["/", "/data"], "metrics_collection_interval": 300 },
                           "swap": { "measurement": ["swap_used_percent"], "metrics_collection_interval": 300 }
                         },
-                        "append_dimensions": { "InstanceId": "${aws:InstanceId}" }
+                        "append_dimensions": { "InstanceId": "${!aws:InstanceId}" }
                       },
                       "logs": {
                         "logs_collected": {
@@ -1145,11 +1511,10 @@ Resources:
               command: "/opt/openclaw/setup.sh"
               ignoreErrors: false
     Properties:
-      ImageId: !Sub 
+      ImageId: !Sub
         - '{{resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/${Arch}/hvm/ebs-gp3/ami-id}}'
         - Arch: !FindInMap [ArchitectureMap, !Ref InstanceType, Arch]
       InstanceType: !Ref InstanceType
-      KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref "AWS::NoValue"]
       IamInstanceProfile: !Ref OpenClawInstanceProfile
       Monitoring: !If [EnableCW, true, false]
       MetadataOptions:
@@ -1160,11 +1525,11 @@ Resources:
         - Device: /dev/sdf
           VolumeId: !If [ProtectData, !Ref OpenClawDataVolumeRetained, !Ref OpenClawDataVolumeNotRetained]
       NetworkInterfaces:
-        - AssociatePublicIpAddress: true
+        - AssociatePublicIpAddress: false
           DeviceIndex: 0
           GroupSet:
             - !Ref OpenClawSecurityGroup
-          SubnetId: !Ref PublicSubnet
+          SubnetId: !Ref PrivateSubnet
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -1193,6 +1558,223 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-instance"
+
+  # ==================== Load Balancer ====================
+  OpenClawALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Condition: EnablePublic
+    Properties:
+      Name: !Sub "${AWS::StackName}-alb"
+      Type: application
+      Scheme: internet-facing
+      IpAddressType: ipv4
+      Subnets:
+        - !Ref PublicSubnet
+        - !Ref PublicSubnet2
+      SecurityGroups:
+        - !Ref ALBSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb"
+
+  OpenClawTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Condition: EnablePublic
+    Properties:
+      Name: !Sub "${AWS::StackName}-tg"
+      Port: 18789
+      Protocol: HTTP
+      VpcId: !Ref OpenClawVPC
+      TargetType: instance
+      HealthCheckEnabled: true
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Targets:
+        - Id: !Ref OpenClawInstance
+          Port: 18789
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-tg"
+
+  OpenClawALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: EnablePublic
+    Properties:
+      LoadBalancerArn: !Ref OpenClawALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: fixed-response
+          FixedResponseConfig:
+            StatusCode: "403"
+            ContentType: "text/plain"
+            MessageBody: "Access Denied"
+
+  OpenClawALBListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: EnablePublic
+    Properties:
+      ListenerArn: !Ref OpenClawALBListener
+      Priority: 1
+      Conditions:
+        - Field: http-header
+          HttpHeaderConfig:
+            HttpHeaderName: X-Custom-Header
+            Values:
+              - !Ref AWS::StackId
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref OpenClawTargetGroup
+
+  # ==================== WAF (Web Application Firewall) ====================
+  # WAF for CloudFront must be created in us-east-1 (global CloudFront service requirement)
+  OpenClawWAFWebACL:
+    Type: AWS::WAFv2::WebACL
+    Condition: CreateWAF
+    Properties:
+      Name: !Sub "${AWS::StackName}-waf"
+      Scope: CLOUDFRONT
+      DefaultAction:
+        Allow: {}
+      Rules:
+        # AWS Managed Rule: Core Rule Set (CRS)
+        - Name: AWSManagedRulesCommonRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesCommonRuleSetMetric
+
+        # AWS Managed Rule: Known Bad Inputs
+        - Name: AWSManagedRulesKnownBadInputsRuleSet
+          Priority: 2
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+
+        # AWS Managed Rule: SQL Injection Protection
+        - Name: AWSManagedRulesSQLiRuleSet
+          Priority: 3
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesSQLiRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesSQLiRuleSetMetric
+
+        # AWS Managed Rule: Linux Operating System Protection
+        - Name: AWSManagedRulesLinuxRuleSet
+          Priority: 4
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesLinuxRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesLinuxRuleSetMetric
+
+        # Rate Limiting Rule (1000 requests per 5 minutes per IP)
+        - Name: RateLimitRule
+          Priority: 5
+          Action:
+            Block:
+              CustomResponse:
+                ResponseCode: 429
+          Statement:
+            RateBasedStatement:
+              Limit: 1000
+              AggregateKeyType: IP
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: RateLimitRuleMetric
+
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub "${AWS::StackName}-waf"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-waf"
+
+  # ==================== CloudFront ====================
+  OpenClawCloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Condition: EnablePublic
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: "OpenClaw - Secured with Shield Standard DDoS Protection + Custom Header + WAF"
+        WebACLId: !If
+          - CreateWAF
+          - !GetAtt OpenClawWAFWebACL.Arn
+          - !Ref AWS::NoValue
+        DefaultCacheBehavior:
+          TargetOriginId: alb-origin
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - POST
+            - PATCH
+            - DELETE
+          CachedMethods:
+            - GET
+            - HEAD
+          ForwardedValues:
+            QueryString: true
+            Headers:
+              - '*'
+            Cookies:
+              Forward: all
+          MinTTL: 0
+          DefaultTTL: 0
+          MaxTTL: 0
+        Origins:
+          - Id: alb-origin
+            DomainName: !GetAtt OpenClawALB.DNSName
+            CustomOriginConfig:
+              HTTPPort: 80
+              OriginProtocolPolicy: http-only
+            OriginCustomHeaders:
+              - HeaderName: X-Custom-Header
+                HeaderValue: !Ref AWS::StackId
+        Restrictions:
+          GeoRestriction:
+            RestrictionType: !If
+              - HasGeoRestriction
+              - whitelist
+              - none
+            Locations: !If
+              - HasGeoRestriction
+              - !Ref AllowedCountries
+              - !Ref AWS::NoValue
 
   # ==================== CloudWatch Alarms ====================
   EC2AutoRecoveryAlarm:
@@ -1234,22 +1816,42 @@ Resources:
         - !Sub "arn:aws:automate:${AWS::Region}:ec2:reboot"
 
 Outputs:
+  CloudFrontURL:
+    Condition: EnablePublic
+    Description: "PUBLIC ACCESS URL (HTTPS) - IP-restricted at ALB security group to 203.220.180.180/32"
+    Value: !Sub
+      - "https://${Domain}/?token=${Token}"
+      - Domain: !GetAtt OpenClawCloudFrontDistribution.DomainName
+        Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
+
+  ALBURL:
+    Condition: EnablePublic
+    Description: "ALB URL (HTTP) - inbound is restricted to cloudfront prefix list via security group"
+    Value: !Sub
+      - "http://${Domain}/?token=${Token}"
+      - Domain: !GetAtt OpenClawALB.DNSName
+        Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
+
   Step1InstallSSMPlugin:
+    Condition: DisablePublic
     Description: "STEP 1: Install SSM Session Manager Plugin on your local computer (Option 2: go to EC2 Console > right-click instance > Connect > Session Manager to get a shell, then run 'sudo su - ubuntu && openclaw gateway status' to set up IM channels)"
     Value: "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
 
   Step2PortForwarding:
+    Condition: DisablePublic
     Description: "STEP 2: Run this command on LOCAL computer (keep terminal open)"
     Value: !Sub |
       aws ssm start-session --target ${OpenClawInstance} --region ${AWS::Region} --document-name AWS-StartPortForwardingSession --parameters '{"portNumber":["18789"],"localPortNumber":["18789"]}'
 
   Step3AccessURL:
+    Condition: DisablePublic
     Description: "STEP 3: Open this URL in browser"
     Value: !Sub
       - "http://localhost:18789/?token=${Token}"
       - Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
 
   Step4StartChatting:
+    Condition: DisablePublic
     Description: "STEP 4: Start using OpenClaw!"
     Value: "Connect WhatsApp, Telegram, Discord. See README: https://github.com/aws-samples/sample-OpenClaw-on-AWS-with-Bedrock"
 
@@ -1267,17 +1869,25 @@ Outputs:
       - |
         EC2 (${InstanceType}): ~$50-60 (c7g.large ~$58, Graviton 20% cheaper than x86)
         EBS (30GB x2): ~$4.80
+        NAT Gateway: ~$33 ($0.045/hour + $0.045/GB data transfer)
         VPC Endpoints: ${EndpointCost}
         Monitoring: ${MonitoringCost}
+        Public Access: ${PublicCost}
+        WAF: ${WAFCost}
         Bedrock: Pay-per-use
         Total: ~${TotalCost}/month
-        Note: Compute-optimized (c7g, 2 vCPU) recommended for running Node.js + Docker sandbox concurrently. Swap, health checks, and OS security patches are always enabled at no extra cost.
-      - EndpointCost: !If [CreateEndpoints, "~$29 ($0.01/hour x 5 endpoints)", "$0 (disabled)"]
+        Note: EC2 in private subnet (NAT Gateway required for internet). Compute-optimized (c7g, 2 vCPU) for Node.js + Docker sandbox. Swap, health checks, OS patches always enabled.
+      - EndpointCost: !If [CreateEndpoints, "~$51 ($0.01/hour x 9 interface endpoints: Bedrock Runtime, Bedrock Mantle, SSM, SSM Messages, EC2 Messages, CloudWatch Logs, CloudFormation, EC2. S3 Gateway free)", "$0 (disabled)"]
         MonitoringCost: !If [EnableCW, "~$4 (CloudWatch Agent + detailed monitoring + alarms + logs)", "$0 (disabled)"]
-        TotalCost: !If 
-          - CreateEndpoints
-          - !If [EnableCW, "$91-96", "$87-92"]
-          - !If [EnableCW, "$63-67", "$58-63"]
+        PublicCost: !If [EnablePublic, "~$25 (ALB ~$22/mo + CloudFront $0.085/GB)", "$0 (SSM only)"]
+        WAFCost: !If [CreateWAF, "~$10 (WebACL $5/mo + 5 rules x $1/mo + requests $0.60/million)", "$0 (disabled or not us-east-1)"]
+        TotalCost: !If
+          - EnablePublic
+          - !If [CreateWAF, "~$180-190", "~$170-180"]
+          - !If
+            - CreateEndpoints
+            - !If [EnableCW, "$146-151", "$142-147"]
+            - !If [EnableCW, "$96-100", "$91-96"]
 
   InstanceArchitecture:
     Description: "Instance architecture"
@@ -1292,3 +1902,27 @@ Outputs:
     Condition: DeleteData
     Description: "Data volume ID (deleted with stack)"
     Value: !Ref OpenClawDataVolumeNotRetained
+
+  S3BucketArn:
+    Description: "S3 bucket ARN"
+    Value: !GetAtt OpenClawS3Bucket.Arn
+
+  SecurityFeatures:
+    Condition: EnablePublic
+    Description: "Security protections enabled"
+    Value: !Sub
+      - |
+        1.AWS Shield Standard (automatic DDoS protection - Layer 3/4)
+        ${WAFStatus}
+        2.CloudFront managed prefix list (only CloudFront IPs can reach ALB)
+        3.Custom header validation (CloudFront → ALB, secret stack ID)
+        4.Direct ALB access blocked (returns 403 without header)
+        5.All traffic via HTTPS (CloudFront enforced)
+        6.EC2 in private subnet (no public IP)
+        7.NAT Gateway for controlled outbound (${NATGatewayEIP})
+        8.VPC Endpoints (S3, Bedrock, CloudWatch - all AWS traffic private)
+        9.No public SSH (SSM Session Manager via VPC endpoints only)
+      - WAFStatus: !If
+          - CreateWAF
+          - "✅ AWS WAF enabled (SQL injection, XSS, rate limiting, bad inputs)"
+          - "⚠️  WAF disabled (only available in us-east-1 region)"

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -82,6 +82,7 @@ Parameters:
     AllowedValues:
       - "2026.3.24"
       - "2026.4.5"
+      - "2026.4.10"
       - "2026.4.27"
       - "latest"
     Description: "OpenClaw version. 2026.3.24 (no model approval needed, WeChat compatible). 2026.4.5+ (auto-discovery, embeddings)."
@@ -97,7 +98,7 @@ Parameters:
   EnableDataProtection:
     Type: String
     Default: "false"
-    Description: "Retain data volume when stack is deleted (protects against accidental data loss)"
+    Description: "If retain both EBS volume and S3 bucket on stack deletion,set to true. Data will be deleted if set to false."
     AllowedValues:
       - "true"
       - "false"
@@ -744,8 +745,14 @@ Resources:
                   - 's3:ListBucket'
                   - 's3:GetBucketLocation'
                 Resource:
-                  - !GetAtt OpenClawS3Bucket.Arn
-                  - !Sub '${OpenClawS3Bucket.Arn}/*'
+                  - !If
+                    - ProtectData
+                    - !GetAtt OpenClawS3BucketRetained.Arn
+                    - !GetAtt OpenClawS3BucketNotRetained.Arn
+                  - !If
+                    - ProtectData
+                    - !Sub '${OpenClawS3BucketRetained.Arn}/*'
+                    - !Sub '${OpenClawS3BucketNotRetained.Arn}/*'
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-instance-role"
@@ -798,10 +805,39 @@ Resources:
           Value: !Sub "${AWS::StackName}-sg"
 
   # ==================== S3 Bucket ====================
-  OpenClawS3Bucket:
+  # Two conditional S3 buckets to match EnableDataProtection parameter behavior (same pattern as EBS volumes)
+  OpenClawS3BucketRetained:
     Type: AWS::S3::Bucket
+    Condition: ProtectData
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "openclaw-${AWS::StackName}-${AWS::AccountId}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteOldVersions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-data-bucket"
+
+  OpenClawS3BucketNotRetained:
+    Type: AWS::S3::Bucket
+    Condition: DeleteData
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       BucketName: !Sub "openclaw-${AWS::StackName}-${AWS::AccountId}"
       BucketEncryption:
@@ -1064,12 +1100,22 @@ Resources:
                       echo "$DATA_DEVICE /data ext4 defaults,nofail 0 2" >> /etc/fstab
                     mkdir -p /data/openclaw
                     chown ubuntu:ubuntu /data/openclaw
-                    # Keep ~/.openclaw symlink for CLI convenience (e.g. 'ls ~/.openclaw').
+
+                    # Create ~/.openclaw symlink for CLI convenience (e.g. 'ls ~/.openclaw').
                     # Set OPENCLAW_STATE_DIR to the real path so OpenClaw's exec approval
-                    # boundary check never traverses the symlink.
-                    [ -L /home/ubuntu/.openclaw ] || ln -sf /data/openclaw /home/ubuntu/.openclaw
+                    # boundary check never traverses the symlink (security boundary requirement).
+                    # Remove existing file/dir/symlink to ensure clean state on re-runs.
+                    if [ -e /home/ubuntu/.openclaw ] || [ -L /home/ubuntu/.openclaw ]; then
+                      rm -rf /home/ubuntu/.openclaw
+                    fi
+                    mkdir -p /home/ubuntu/.openclaw
+                    chown -h ubuntu:ubuntu /home/ubuntu/.openclaw
+
+                    # Set OPENCLAW_STATE_DIR environment variable to point to real path
+                    # (not the symlink) for OpenClaw's security boundary checks
                     mkdir -p /home/ubuntu/.config/environment.d
-                    echo "OPENCLAW_STATE_DIR=/data/openclaw" >> /home/ubuntu/.config/environment.d/openclaw.conf
+                    echo "OPENCLAW_STATE_DIR=/data/openclaw" > /home/ubuntu/.config/environment.d/openclaw.conf
+                    chown ubuntu:ubuntu /home/ubuntu/.config/environment.d/openclaw.conf
                   else
                     echo "FATAL: no data volume found — expected an EBS volume attached at /dev/nvme1n1, /dev/xvdf, or /dev/sdf"
                     exit 1
@@ -1867,7 +1913,6 @@ Outputs:
       - "https://${Domain}/?token=<token>"
       - Domain: !GetAtt OpenClawCloudFrontDistribution.DomainName
 
-
   ALBURL:
     Condition: EnablePublic
     Description: "ALB URL (HTTP) - Replace <token> with the value from the output 'GetToken'. Not secured, for testing/debugging only (bypasses CloudFront)."
@@ -1944,26 +1989,16 @@ Outputs:
     Description: "Data volume ID (deleted with stack)"
     Value: !Ref OpenClawDataVolumeNotRetained
 
-  S3BucketArn:
-    Description: "S3 bucket ARN"
-    Value: !GetAtt OpenClawS3Bucket.Arn
+  S3BucketNameRetained:
+    Condition: ProtectData
+    Description: "S3 bucket name (retained on stack delete)"
+    Value: !Ref OpenClawS3BucketRetained
+
+  S3BucketNameNotRetained:
+    Condition: DeleteData
+    Description: "S3 bucket name (deleted with stack)"
+    Value: !Ref OpenClawS3BucketNotRetained
 
   SecurityFeatures:
-    Condition: EnablePublic
-    Description: "Security protections enabled"
-    Value: !Sub
-      - |
-        1.AWS Shield Standard (automatic DDoS protection - Layer 3/4)
-        ${WAFStatus}
-        2.CloudFront managed prefix list (only CloudFront IPs can reach ALB)
-        3.Custom header validation (CloudFront → ALB, secret stack ID)
-        4.Direct ALB access blocked (returns 403 without header)
-        5.All traffic via HTTPS (CloudFront enforced)
-        6.EC2 in private subnet (no public IP)
-        7.NAT Gateway for controlled outbound (${NATGatewayEIP})
-        8.VPC Endpoints (S3, Bedrock, CloudWatch - all AWS traffic private)
-        9.No public SSH (SSM Session Manager via VPC endpoints only)
-      - WAFStatus: !If
-          - CreateWAF
-          - "✅ AWS WAF enabled (SQL injection, XSS, rate limiting, bad inputs)"
-          - "⚠️  WAF disabled (only available in us-east-1 region)"
+    Description: "Security protections available in this deployment"
+    Value: "See the SECURITY.md document athttps://github.com/aws-samples/sample-OpenClaw-on-AWS-with-Bedrock/blob/main/SECURITY.md"

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -1855,21 +1855,25 @@ Resources:
         - !Sub "arn:aws:automate:${AWS::Region}:ec2:reboot"
 
 Outputs:
+  GetToken:
+    Description: "Get OpenClaw Gateway Token from SSM Parameter Store"
+    Value: !Sub |
+      aws ssm get-parameter --name /openclaw/${AWS::StackName}/gateway-token --with-decryption --query Parameter.Value --output text --region ${AWS::Region}
+
   CloudFrontURL:
     Condition: EnablePublic
-    Description: "PUBLIC ACCESS URL (HTTPS) - IP-restricted at ALB security group to 203.220.180.180/32"
+    Description: "PUBLIC ACCESS URL (HTTPS). Replace <token> with the value from the output 'GetToken'"
     Value: !Sub
-      - "https://${Domain}/?token=${Token}"
+      - "https://${Domain}/?token=<token>"
       - Domain: !GetAtt OpenClawCloudFrontDistribution.DomainName
-        Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
+
 
   ALBURL:
     Condition: EnablePublic
-    Description: "ALB URL (HTTP) - inbound is restricted to cloudfront prefix list via security group"
+    Description: "ALB URL (HTTP) - Replace <token> with the value from the output 'GetToken'. Not secured, for testing/debugging only (bypasses CloudFront)."
     Value: !Sub
-      - "http://${Domain}/?token=${Token}"
+      - "http://${Domain}/?token=<token>"
       - Domain: !GetAtt OpenClawALB.DNSName
-        Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
 
   Step1InstallSSMPlugin:
     Condition: DisablePublic
@@ -1884,10 +1888,8 @@ Outputs:
 
   Step3AccessURL:
     Condition: DisablePublic
-    Description: "STEP 3: Open this URL in browser"
-    Value: !Sub
-      - "http://localhost:18789/?token=${Token}"
-      - Token: !Select [3, !Split ['"', !GetAtt OpenClawWaitCondition.Data]]
+    Description: "STEP 3: Open in browser (replace <token> with value from the output 'GetToken')"
+    Value: "http://localhost:18789/?token=<token>"     
 
   Step4StartChatting:
     Condition: DisablePublic

--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -113,7 +113,7 @@ Parameters:
 
   EnableWAF:
     Type: String
-    Default: "true"
+    Default: "false"
     Description: "Enable AWS WAF for CloudFront (Layer 7 DDoS protection, SQL injection, XSS). WAF must be created in us-east-1."
     AllowedValues:
       - "true"
@@ -266,24 +266,6 @@ Resources:
       VpcId: !Ref OpenClawVPC
       InternetGatewayId: !Ref OpenClawInternetGateway
 
-  # NAT Gateway for private subnet internet access
-  NATGatewayEIP:
-    Type: AWS::EC2::EIP
-    DependsOn: AttachGateway
-    Properties:
-      Domain: vpc
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-nat-eip"
-
-  NATGateway:
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt NATGatewayEIP.AllocationId
-      SubnetId: !Ref PublicSubnet
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-nat-gateway"
 
   PublicSubnet:
     Type: AWS::EC2::Subnet
@@ -310,6 +292,7 @@ Resources:
 
   PrivateSubnet:
     Type: AWS::EC2::Subnet
+    Condition: CreateEndpoints
     Properties:
       VpcId: !Ref OpenClawVPC
       CidrBlock: "10.0.2.0/24"
@@ -358,24 +341,19 @@ Resources:
       SubnetId: !Ref PublicSubnet2
       RouteTableId: !Ref PublicRouteTable
 
-  # Private Route Table for private subnets
+  # Private Route Table for private subnets (VPC endpoints only, no NAT)
   PrivateRouteTable:
     Type: AWS::EC2::RouteTable
+    Condition: CreateEndpoints
     Properties:
       VpcId: !Ref OpenClawVPC
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-private-rtb"
 
-  PrivateRoute:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId: !Ref PrivateRouteTable
-      DestinationCidrBlock: "0.0.0.0/0"
-      NatGatewayId: !Ref NATGateway
-
   PrivateSubnetRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: CreateEndpoints
     Properties:
       SubnetId: !Ref PrivateSubnet
       RouteTableId: !Ref PrivateRouteTable
@@ -388,17 +366,20 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
 
   # ==================== Network ACLs for Private Subnet Security ====================
+  # Private subnet now used only for VPC endpoints (when enabled)
   PrivateNetworkAcl:
     Type: AWS::EC2::NetworkAcl
+    Condition: CreateEndpoints
     Properties:
       VpcId: !Ref OpenClawVPC
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-private-nacl"
 
-  # Inbound Rules
-  PrivateNetworkAclInboundHTTP:
+  # Inbound Rules - only from VPC CIDR for VPC endpoints
+  PrivateNetworkAclInboundHTTPS:
     Type: AWS::EC2::NetworkAclEntry
+    Condition: CreateEndpoints
     Properties:
       NetworkAclId: !Ref PrivateNetworkAcl
       RuleNumber: 100
@@ -406,35 +387,12 @@ Resources:
       RuleAction: allow
       CidrBlock: 10.0.0.0/16
       PortRange:
-        From: 80
-        To: 80
-
-  PrivateNetworkAclInboundHTTPS:
-    Type: AWS::EC2::NetworkAclEntry
-    Properties:
-      NetworkAclId: !Ref PrivateNetworkAcl
-      RuleNumber: 110
-      Protocol: 6
-      RuleAction: allow
-      CidrBlock: 10.0.0.0/16
-      PortRange:
         From: 443
         To: 443
-
-  PrivateNetworkAclInboundOpenClaw:
-    Type: AWS::EC2::NetworkAclEntry
-    Properties:
-      NetworkAclId: !Ref PrivateNetworkAcl
-      RuleNumber: 120
-      Protocol: 6
-      RuleAction: allow
-      CidrBlock: 10.0.0.0/16
-      PortRange:
-        From: 18789
-        To: 18789
 
   PrivateNetworkAclInboundEphemeral:
     Type: AWS::EC2::NetworkAclEntry
+    Condition: CreateEndpoints
     Properties:
       NetworkAclId: !Ref PrivateNetworkAcl
       RuleNumber: 130
@@ -445,9 +403,10 @@ Resources:
         From: 1024
         To: 65535
 
-  # Outbound Rules - Restrictive (only HTTPS + DNS)
+  # Outbound Rules - only HTTPS for VPC endpoint traffic
   PrivateNetworkAclOutboundHTTPS:
     Type: AWS::EC2::NetworkAclEntry
+    Condition: CreateEndpoints
     Properties:
       NetworkAclId: !Ref PrivateNetworkAcl
       RuleNumber: 100
@@ -459,34 +418,9 @@ Resources:
         From: 443
         To: 443
 
-  PrivateNetworkAclOutboundHTTP:
-    Type: AWS::EC2::NetworkAclEntry
-    Properties:
-      NetworkAclId: !Ref PrivateNetworkAcl
-      RuleNumber: 110
-      Protocol: 6
-      Egress: true
-      RuleAction: allow
-      CidrBlock: 0.0.0.0/0
-      PortRange:
-        From: 80
-        To: 80
-
-  PrivateNetworkAclOutboundDNS:
-    Type: AWS::EC2::NetworkAclEntry
-    Properties:
-      NetworkAclId: !Ref PrivateNetworkAcl
-      RuleNumber: 120
-      Protocol: 17
-      Egress: true
-      RuleAction: allow
-      CidrBlock: 0.0.0.0/0
-      PortRange:
-        From: 53
-        To: 53
-
   PrivateNetworkAclOutboundEphemeral:
     Type: AWS::EC2::NetworkAclEntry
+    Condition: CreateEndpoints
     Properties:
       NetworkAclId: !Ref PrivateNetworkAcl
       RuleNumber: 130
@@ -497,12 +431,6 @@ Resources:
       PortRange:
         From: 1024
         To: 65535
-
-  PrivateSubnetNetworkAclAssociation:
-    Type: AWS::EC2::SubnetNetworkAclAssociation
-    Properties:
-      SubnetId: !Ref PrivateSubnet
-      NetworkAclId: !Ref PrivateNetworkAcl
 
   PrivateSubnetNetworkAclAssociation2:
     Type: AWS::EC2::SubnetNetworkAclAssociation
@@ -1580,11 +1508,11 @@ Resources:
         - Device: /dev/sdf
           VolumeId: !If [ProtectData, !Ref OpenClawDataVolumeRetained, !Ref OpenClawDataVolumeNotRetained]
       NetworkInterfaces:
-        - AssociatePublicIpAddress: false
+        - AssociatePublicIpAddress: true
           DeviceIndex: 0
           GroupSet:
             - !Ref OpenClawSecurityGroup
-          SubnetId: !Ref PrivateSubnet
+          SubnetId: !Ref PublicSubnet
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -1918,25 +1846,24 @@ Outputs:
       - |
         EC2 (${InstanceType}): ~$50-60 (c7g.large ~$58, Graviton 20% cheaper than x86)
         EBS (30GB x2): ~$4.80
-        NAT Gateway: ~$33 ($0.045/hour + $0.045/GB data transfer)
         VPC Endpoints: ${EndpointCost}
         Monitoring: ${MonitoringCost}
         Public Access: ${PublicCost}
         WAF: ${WAFCost}
         Bedrock: Pay-per-use
         Total: ~${TotalCost}/month
-        Note: EC2 in private subnet (NAT Gateway required for internet). Compute-optimized (c7g, 2 vCPU) for Node.js + Docker sandbox. Swap, health checks, OS patches always enabled.
-      - EndpointCost: !If [CreateEndpoints, "~$51 ($0.01/hour x 9 interface endpoints: Bedrock Runtime, Bedrock Mantle, SSM, SSM Messages, EC2 Messages, CloudWatch Logs, CloudFormation, EC2. S3 Gateway free)", "$0 (disabled)"]
+        Note: EC2 in public subnet with direct internet access (no NAT Gateway). Compute-optimized (c7g, 2 vCPU) for Node.js + Docker sandbox. Swap, health checks, OS patches always enabled.
+      - EndpointCost: !If [CreateEndpoints, "~$88 ($0.01/hour/AZ x 2 AZs x 6 interface endpoints = $14.60/endpoint/mo: Bedrock Runtime, Bedrock Mantle (conditional), SSM, SSM Messages, EC2 Messages, CloudWatch Logs. S3 Gateway free)", "$0 (disabled)"]
         MonitoringCost: !If [EnableCW, "~$4 (CloudWatch Agent + detailed monitoring + alarms + logs)", "$0 (disabled)"]
         PublicCost: !If [EnablePublic, "~$25 (ALB ~$22/mo + CloudFront $0.085/GB)", "$0 (SSM only)"]
         WAFCost: !If [CreateWAF, "~$10 (WebACL $5/mo + 5 rules x $1/mo + requests $0.60/million)", "$0 (disabled or not us-east-1)"]
         TotalCost: !If
           - EnablePublic
-          - !If [CreateWAF, "~$180-190", "~$170-180"]
+          - !If [CreateWAF, "~$188", "~$178"]
           - !If
             - CreateEndpoints
-            - !If [EnableCW, "$146-151", "$142-147"]
-            - !If [EnableCW, "$96-100", "$91-96"]
+            - !If [EnableCW, "~$155", "~$151"]
+            - !If [EnableCW, "~$67", "~$63"]
 
   InstanceArchitecture:
     Description: "Instance architecture"


### PR DESCRIPTION
to avoid triggering sev2, made the following improvement to stronger the security control:
1. removed SSH key
2. Added ALB and cloudfront, WAF options
3. If enable ALB+CloudFront, the default "AllowedCountry" restricts CloudFront access to Australia (AU) only.  These parameters are allowed to change.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
