### PR TITLE
fix: escape Fn::Sub variable and fix heredoc terminator in CloudWatch Agent config

### DIFF
--- a/clawdbot-bedrock.yaml
+++ b/clawdbot-bedrock.yaml
@@ -1107,7 +1107,7 @@ Resources:
                           "disk": { "measurement": ["disk_used_percent"], "resources": ["/", "/data"], "metrics_collection_interval": 300 },
                           "swap": { "measurement": ["swap_used_percent"], "metrics_collection_interval": 300 }
                         },
-                        "append_dimensions": { "InstanceId": "${aws:InstanceId}" }
+                        "append_dimensions": { "InstanceId": "${!aws:InstanceId}" }
                       },
                       "logs": {
                         "logs_collected": {
@@ -1120,7 +1120,7 @@ Resources:
                         }
                       }
                     }
-                    CWCONFIG
+                  CWCONFIG
                     /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json || echo "CloudWatch Agent config failed"
                   else
                     echo "[post] Skipping CloudWatch Agent (EnableMonitoring=false)..."


### PR DESCRIPTION
  ## Summary
  
  Fixes two bugs in `clawdbot-bedrock.yaml` that break CloudWatch Agent deployment when `EnableMonitoring=true`.
  
  Fixes #131
  Fixes #132
  
  ## Changes
  
  ### #131 — `Fn::Sub` treats `${aws:InstanceId}` as CFN reference
  
  The CloudWatch Agent config uses `${aws:InstanceId}` as a runtime variable the agent resolves itself. Since the script is inside `Fn::Sub: |`,
  CloudFormation tries to resolve it and fails with `Unresolved resource dependencies [aws:InstanceId]`.
  
  **Fix:** Escape as `${!aws:InstanceId}` — same pattern already used on lines 742, 743, 779.
  
  ### #132 — Heredoc terminator indented, breaks script execution
  
  The `CWCONFIG` terminator had 2 extra spaces of indent. After YAML strips the base indent, bash never recognizes it as end-of-heredoc — causing all
  subsequent commands (including `amazon-cloudwatch-agent-ctl`) to be swallowed as heredoc content.
  
  **Fix:** Dedent `CWCONFIG` terminator to base indent level.