### PR TITLE
fix: restore Monitor/Audit event visibility in admin console

### DIFF
--- a/enterprise/admin-console/server/db.py
+++ b/enterprise/admin-console/server/db.py
@@ -45,12 +45,26 @@ def _clean(item: dict) -> dict:
 
 
 def _query(sk_prefix: str) -> list[dict]:
-    """Query all items with given SK prefix under ORG#acme."""
+    """Query ALL items with given SK prefix under ORG#acme, following pagination.
+
+    A single DynamoDB Query returns at most 1MB of items; without paginating,
+    high-volume prefixes like AUDIT# (thousands of rows) only returned their
+    first page — and since Query defaults to ascending key order, that page held
+    the OLDEST records, so recent-window views (e.g. Agent Activity last 24h)
+    came back empty. We now loop on LastEvaluatedKey to fetch every page."""
     try:
-        resp = _get_table().query(
-            KeyConditionExpression=Key("PK").eq(ORG_PK) & Key("SK").begins_with(sk_prefix)
-        )
-        return [_clean(item) for item in resp.get("Items", [])]
+        table = _get_table()
+        kce = Key("PK").eq(ORG_PK) & Key("SK").begins_with(sk_prefix)
+        items: list = []
+        kwargs: dict = {"KeyConditionExpression": kce}
+        while True:
+            resp = table.query(**kwargs)
+            items.extend(resp.get("Items", []))
+            lek = resp.get("LastEvaluatedKey")
+            if not lek:
+                break
+            kwargs["ExclusiveStartKey"] = lek
+        return [_clean(item) for item in items]
     except ClientError as e:
         print(f"[db] DynamoDB query error: {e}")
         return []
@@ -385,8 +399,24 @@ def create_binding(data: dict) -> dict:
 
 # === Audit Entries ===
 
-def get_audit_entries(limit: int = 50) -> list[dict]:
+def _is_system_audit_event(e: dict) -> bool:
+    """Internal warmup / heartbeat / scheduled-task events that are not real
+    business activity. These come from the ACTI scheduler (session warmup pings,
+    HEARTBEAT.md reads) under the synthetic actor "a" and would otherwise drown
+    out real employee/admin events in the timeline (they are ~93% of all audit
+    rows). Identified by the dedicated ACTI channel, with actor "a" as a fallback."""
+    if e.get("channel") == "ACTI":
+        return True
+    if e.get("actorId") == "a" or e.get("actorName") == "a":
+        return True
+    detail = (e.get("detail") or "")
+    return detail.startswith("ACTI chat:") or "[SYSTEM] Session warmup" in detail
+
+
+def get_audit_entries(limit: int = 50, include_system: bool = False) -> list[dict]:
     items = _query("AUDIT#")
+    if not include_system:
+        items = [e for e in items if not _is_system_audit_event(e)]
     items.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
     return items[:limit]
 

--- a/enterprise/admin-console/server/routers/audit.py
+++ b/enterprise/admin-console/server/routers/audit.py
@@ -44,12 +44,17 @@ def get_audit_entries(
     eventType: Optional[str] = None,
     since: Optional[str] = None,
     before: Optional[str] = None,
+    includeSystem: bool = False,
     authorization: str = Header(default=""),
 ):
-    """Audit event timeline with filtering by type, time range, and department scope."""
+    """Audit event timeline with filtering by type, time range, and department scope.
+
+    By default, internal warmup/heartbeat events (ACTI scheduler, actor "a") are
+    excluded so the timeline shows real employee/admin activity. Pass
+    includeSystem=true to surface them too."""
     user = require_auth(authorization)
     limit = min(limit, 500)
-    entries = db.get_audit_entries(limit=limit)
+    entries = db.get_audit_entries(limit=limit, include_system=includeSystem)
 
     if eventType:
         entries = [e for e in entries if e.get("eventType") == eventType]

--- a/enterprise/admin-console/server/routers/monitor.py
+++ b/enterprise/admin-console/server/routers/monitor.py
@@ -179,6 +179,13 @@ def get_sessions(authorization: str = Header(default="")):
 
     enriched = []
     for s in db_sessions:
+        # Playground (pgnd__) and internal scheduled-task (acti__) sessions are not
+        # real monitored conversations: Playground is read-only by design and never
+        # persists CONV# turns (agent-container server.py), so they would always open
+        # to an empty "No conversation history" view and mislead operators.
+        sid = s.get("id", "") or s.get("sessionId", "")
+        if sid.startswith("pgnd__") or sid.startswith("acti__"):
+            continue
         eid = s.get("employeeId", "")
         if not eid or eid == "unknown":
             continue

--- a/enterprise/admin-console/src/hooks/useApi.ts
+++ b/enterprise/admin-console/src/hooks/useApi.ts
@@ -261,10 +261,11 @@ export function useMonitorAgentActivity() {
 
 // === Audit ===
 
-export function useAuditEntries(params?: { limit?: number; eventType?: string }) {
+export function useAuditEntries(params?: { limit?: number; eventType?: string; includeSystem?: boolean }) {
   const qs = new URLSearchParams();
   if (params?.limit) qs.set('limit', String(params.limit));
   if (params?.eventType && params.eventType !== 'all') qs.set('eventType', params.eventType);
+  if (params?.includeSystem) qs.set('includeSystem', 'true');
   return useQuery<AuditEntry[]>({
     queryKey: ['audit', params],
     queryFn: () => api.get(`/audit/entries?${qs}`),

--- a/enterprise/admin-console/src/pages/AuditLog.tsx
+++ b/enterprise/admin-console/src/pages/AuditLog.tsx
@@ -55,10 +55,11 @@ export default function AuditLog() {
   const [beforeDate, setBeforeDate] = useState('');
   const [analyzingId, setAnalyzingId] = useState<string | null>(null);
   const [analyzeResult, setAnalyzeResult] = useState<Record<string, any>>({});
+  const [includeSystem, setIncludeSystem] = useState(false);
   const pageSize = 10;
   const navigate = useNavigate();
 
-  const { data: AUDIT_ENTRIES = [] } = useAuditEntries({ limit: 50, eventType: eventType !== 'all' ? eventType : undefined });
+  const { data: AUDIT_ENTRIES = [] } = useAuditEntries({ limit: 50, eventType: eventType !== 'all' ? eventType : undefined, includeSystem });
   const { data: insightsData, refetch: refetchInsights } = useAuditInsights();
   const { data: guardrailData } = useGuardrailEvents(50);
   const { data: reviewsData, refetch: refetchReviews } = useAuditReviews();
@@ -365,6 +366,13 @@ export default function AuditLog() {
                       className="text-xs text-primary-light hover:underline">Clear</button>
                   )}
                 </div>
+                <label className="flex items-center gap-2 cursor-pointer select-none ml-auto"
+                  title="Include internal warmup/heartbeat (ACTI) events">
+                  <input type="checkbox" checked={includeSystem}
+                    onChange={e => { setIncludeSystem(e.target.checked); setCurrentPage(1); }}
+                    className="h-4 w-4 rounded border-dark-border bg-dark-bg accent-primary cursor-pointer" />
+                  <span className="text-xs text-text-muted">Show system events</span>
+                </label>
               </div>
 
               {/* Timeline View */}

--- a/enterprise/clawdbot-bedrock-agentcore-multitenancy.yaml
+++ b/enterprise/clawdbot-bedrock-agentcore-multitenancy.yaml
@@ -1232,7 +1232,11 @@ Resources:
                   - !Sub "${TenantWorkspaceBucket.Arn}/*"
               - Sid: DynamoDBReadOnly
                 Effect: Allow
-                Action: [dynamodb:GetItem, dynamodb:Query]
+                # PutItem/UpdateItem are required so the restricted tier can write
+                # its own audit trail (agent_invocation, guardrail_block, usage).
+                # Without them, guardrail blocks are silently dropped (AccessDenied)
+                # and never appear in the Audit Center.
+                Action: [dynamodb:GetItem, dynamodb:Query, dynamodb:PutItem, dynamodb:UpdateItem]
                 Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}*"
               - Sid: SSMRead
                 Effect: Allow


### PR DESCRIPTION
## Summary

Three related fixes so the enterprise admin console shows **real activity** instead of empty or noise-flooded views. All verified live on the production env (`openclaw-jiade2`, ap-northeast-1).

## What was wrong & fixed

1. **`_query()` had no pagination** (`db.py`) — a single DynamoDB Query returns at most 1MB, so high-volume prefixes (`AUDIT#` ~4.7k rows, `CONV#` ~8.4k rows) only returned their **first (oldest) page**. The Monitor *"Agent Activity (Last 24h)"* widget and the audit timeline came back **empty despite live traffic**. Now loops on `LastEvaluatedKey` to fetch all pages.

2. **Warmup/heartbeat noise flooded the audit views** (`db.py` / `audit.py` / `useApi.ts` / `AuditLog.tsx`) — internal ACTI scheduler events (actor `"a"`) were ~93% of all audit rows and buried real employee/admin activity. Now filtered by default, with a **"Show system events"** toggle to surface them on demand.

3. **Playground sessions showed as empty in Live Sessions** (`monitor.py`) — `pgnd__` (Playground) and `acti__` (scheduled task) sessions never persist conversation turns, so they always opened to *"No conversation history"*. Now excluded from the Live Sessions list.

4. **Guardrail blocks were silently dropped** (CFN template) — the restricted tier role lacked `dynamodb:PutItem`/`UpdateItem`, so `guardrail_block` audit events failed with AccessDenied and never reached the Audit Center. Template now grants them. *(Note: the running AgentCore restricted role was fixed live; this template change covers the Fargate path to prevent regression.)*

## Verification

- `_query(AUDIT#)` now returns all 4715 rows (was first page only)
- Agent Activity 24h: 0 → 19+ events
- Live Sessions: 26 → 18 (8 pgnd/acti noise filtered)
- Guardrail blocks now persist and appear in Audit Center (verified with Carol/Rachel/David restricted-tier blocks)

## Not included

- CONV# negative-sequence fix in `agent-container/server.py` — code ready but requires a container image rebuild; deferred to a maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)