### PR TITLE
fix: always-on ECS agent EFS persistence + admin workspace control

### DIFF
--- a/enterprise/admin-console/server/routers/admin_always_on.py
+++ b/enterprise/admin-console/server/routers/admin_always_on.py
@@ -87,6 +87,12 @@ def _build_agent_env(agent: dict, agent_id: str, stack: str, bucket: str,
 
     model, guardrail, _, _ = _TIER_DEFAULTS.get(tier, _TIER_DEFAULTS["standard"])
 
+    # Pre-authorized Discord user IDs (skip interactive DM pairing). Stored on the
+    # agent record as discordAllowFrom (list or comma-separated string).
+    allow_from = agent.get("discordAllowFrom", "")
+    if isinstance(allow_from, list):
+        allow_from = ",".join(str(x) for x in allow_from)
+
     return [
         {"name": "SESSION_ID",         "value": session_id},
         {"name": "SHARED_AGENT_ID",    "value": agent_id},
@@ -102,6 +108,7 @@ def _build_agent_env(agent: dict, agent_id: str, stack: str, bucket: str,
         {"name": "FARGATE_TIER",       "value": tier},
         {"name": "TELEGRAM_BOT_TOKEN", "value": telegram_token},
         {"name": "DISCORD_BOT_TOKEN",  "value": discord_token},
+        {"name": "DISCORD_ALLOW_FROM", "value": allow_from},
     ]
 
 
@@ -271,6 +278,14 @@ def start_always_on_agent(agent_id: str, authorization: str = Header(default="")
                 access_point_id = _create_access_point(efs_id, emp_id)
         except Exception as e:
             print(f"[always-on] Access Point creation failed (non-fatal): {e}")
+
+        # Tell the container whether EFS is mounted via an access point. The access
+        # point root is already scoped to /{employee}, so the entrypoint must NOT
+        # append the employee id again (avoids /emp-x/emp-x/workspace double-prefix
+        # that diverges from the admin console's root-mounted /emp-x/workspace view).
+        env_vars = [e for e in env_vars if e.get("name") != "EFS_ACCESS_POINT"]
+        env_vars.append({"name": "EFS_ACCESS_POINT",
+                         "value": "true" if access_point_id else "false"})
 
         # Check if service already exists
         service_exists = False
@@ -523,9 +538,17 @@ def reload_always_on_agent(agent_id: str, body: dict, authorization: str = Heade
     ecs_cfg = _get_ecs_config()
     service_name = _ecs_service_name(agent_id)
 
+    # Resolve per-tier config so reload preserves the employee's tier (model, CPU,
+    # memory, task role) instead of silently regressing to base/standard defaults.
+    emp_id = agent.get("employeeId", agent_id)
+    tier = _resolve_tier(emp_id)
+    _, _, tier_cpu, tier_memory = _TIER_DEFAULTS.get(tier, _TIER_DEFAULTS["standard"])
+    tier_role_arn = _get_tier_role_arn(stack, tier)
+
     telegram_token, discord_token = _resolve_bot_tokens(stack, agent_id)
     env_vars = _build_agent_env(agent, agent_id, stack, bucket,
-                                ddb_table, ddb_region, telegram_token, discord_token)
+                                ddb_table, ddb_region, telegram_token, discord_token,
+                                tier=tier)
 
     try:
         ecs = boto3.client("ecs", region_name=GATEWAY_REGION)
@@ -544,14 +567,14 @@ def reload_always_on_agent(agent_id: str, body: dict, authorization: str = Heade
         agent_family = f"{stack}-ao-{service_name}"
         agent_td = ecs.register_task_definition(
             family=agent_family,
-            taskRoleArn=base_td["taskRoleArn"],
+            taskRoleArn=tier_role_arn,
             executionRoleArn=base_td["executionRoleArn"],
             networkMode="awsvpc",
             containerDefinitions=clean_containers,
             volumes=base_td.get("volumes", []),
             requiresCompatibilities=["FARGATE"],
-            cpu=base_td.get("cpu", "512"),
-            memory=base_td.get("memory", "1024"),
+            cpu=tier_cpu,
+            memory=tier_memory,
             runtimePlatform={"cpuArchitecture": "ARM64", "operatingSystemFamily": "LINUX"},
         )
         agent_td_arn = agent_td["taskDefinition"]["taskDefinitionArn"]

--- a/enterprise/admin-console/server/s3ops.py
+++ b/enterprise/admin-console/server/s3ops.py
@@ -14,6 +14,60 @@ AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 _s3 = None
 _bucket = None
 
+# === EFS redirection for always-on ECS agents ===
+# Always-on ECS containers persist their workspace on EFS (mounted at /mnt/efs on
+# this box), NOT S3 — the container's watchdog skips S3 sync in EFS mode. So admin
+# edits to an always-on employee's personal workspace must go to EFS to be visible
+# to the running container (and vice versa). Shared layers (_shared/...) stay on S3.
+EFS_ROOT = os.environ.get("EFS_ROOT", "/mnt/efs")
+_always_on_cache: dict = {}   # emp_id -> bool, short-lived
+_always_on_cache_ts: dict = {}
+
+
+def _is_always_on_employee(emp_id: str) -> bool:
+    """Return True if this employee runs an always-on ECS agent (workspace on EFS).
+    Cached for 30s to avoid a DynamoDB read on every file op."""
+    if not emp_id:
+        return False
+    import time as _t
+    now = _t.time()
+    ts = _always_on_cache_ts.get(emp_id, 0)
+    if now - ts < 30 and emp_id in _always_on_cache:
+        return _always_on_cache[emp_id]
+    result = False
+    try:
+        import db as _db
+        emp = _db.get_employee(emp_id)
+        if emp and emp.get("alwaysOnEnabled"):
+            result = True
+    except Exception:
+        result = False
+    _always_on_cache[emp_id] = result
+    _always_on_cache_ts[emp_id] = now
+    return result
+
+
+def _efs_path_for_key(key: str) -> Optional[str]:
+    """Map an S3 personal-workspace key to its EFS path, IF the owning employee runs
+    always-on. Returns None for non-personal keys or serverless employees (→ use S3).
+
+    Personal key format: '{emp_id}/workspace/...'  →  '/mnt/efs/{emp_id}/workspace/...'
+    """
+    parts = key.split("/", 1)
+    if len(parts) != 2:
+        return None
+    emp_id, rest = parts[0], parts[1]
+    # Only personal workspace keys; shared layers (_shared/...) always live on S3.
+    if not rest.startswith("workspace/"):
+        return None
+    if not emp_id.startswith("emp-"):
+        return None
+    if not _is_always_on_employee(emp_id):
+        return None
+    if not os.path.isdir(os.path.join(EFS_ROOT, emp_id, "workspace")):
+        return None
+    return os.path.join(EFS_ROOT, emp_id, rest)
+
 
 def _client():
     global _s3
@@ -37,7 +91,14 @@ def bucket():
 
 
 def read_file(key: str) -> Optional[str]:
-    """Read a text file from S3."""
+    """Read a text file. Always-on personal workspace → EFS; otherwise S3."""
+    efs = _efs_path_for_key(key)
+    if efs is not None:
+        try:
+            with open(efs, encoding="utf-8") as f:
+                return f.read()
+        except (OSError, FileNotFoundError):
+            return None
     try:
         obj = _client().get_object(Bucket=bucket(), Key=key)
         return obj["Body"].read().decode("utf-8")
@@ -46,7 +107,18 @@ def read_file(key: str) -> Optional[str]:
 
 
 def write_file(key: str, content: str, metadata: Optional[dict] = None) -> bool:
-    """Write a text file to S3. S3 versioning handles history automatically."""
+    """Write a text file. Always-on personal workspace → EFS (live to container);
+    otherwise S3 (versioning handles history)."""
+    efs = _efs_path_for_key(key)
+    if efs is not None:
+        try:
+            os.makedirs(os.path.dirname(efs), exist_ok=True)
+            with open(efs, "w", encoding="utf-8") as f:
+                f.write(content)
+            return True
+        except OSError as e:
+            print(f"[s3ops] EFS write error: {e}")
+            return False
     try:
         extra = {}
         if metadata:
@@ -64,7 +136,31 @@ def write_file(key: str, content: str, metadata: Optional[dict] = None) -> bool:
 
 
 def list_files(prefix: str) -> list[dict]:
-    """List files under a prefix."""
+    """List files under a prefix. Always-on personal workspace → EFS; otherwise S3."""
+    # EFS redirect: prefix like 'emp-x/workspace/...' for an always-on employee.
+    efs_dir = _efs_path_for_key(prefix.rstrip("/") + "/_") if prefix else None
+    if efs_dir is not None:
+        efs_base = os.path.dirname(efs_dir)  # strip the '_' sentinel
+        files = []
+        if os.path.isdir(efs_base):
+            for root, _dirs, fnames in os.walk(efs_base):
+                for fname in fnames:
+                    fpath = os.path.join(root, fname)
+                    rel = os.path.relpath(fpath, efs_base)
+                    # Reconstruct the S3-style key so callers see a consistent shape
+                    key = prefix + rel
+                    try:
+                        st = os.stat(fpath)
+                        files.append({
+                            "key": key,
+                            "name": rel,
+                            "size": st.st_size,
+                            "lastModified": datetime.fromtimestamp(
+                                st.st_mtime, timezone.utc).isoformat(),
+                        })
+                    except OSError:
+                        pass
+        return files
     files = []
     try:
         paginator = _client().get_paginator("list_objects_v2")

--- a/enterprise/agent-container/entrypoint.sh
+++ b/enterprise/agent-container/entrypoint.sh
@@ -49,12 +49,22 @@ export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--dns-result-order=ipv4first
 # On first start (empty EFS dir), bootstrap from S3. No watchdog needed.
 EFS_MODE=false
 if [ "${EFS_ENABLED:-}" = "true" ] && [ -d "/mnt/efs" ]; then
-    EFS_WORKSPACE="/mnt/efs/${BASE_TENANT_ID}/workspace"
+    # Path layout depends on how the EFS volume is mounted:
+    #  - Access-point mode (EFS_ACCESS_POINT=true): the access point root is already
+    #    scoped to /{employee} on EFS, so /mnt/efs IS the employee's directory. Do NOT
+    #    append BASE_TENANT_ID again or we get /emp-x/emp-x/workspace (double-prefix),
+    #    which diverges from the admin console (root-mount → /emp-x/workspace).
+    #  - Root mode (no access point): /mnt/efs is the EFS root, so scope by employee.
+    if [ "${EFS_ACCESS_POINT:-}" = "true" ]; then
+        EFS_WORKSPACE="/mnt/efs/workspace"
+    else
+        EFS_WORKSPACE="/mnt/efs/${BASE_TENANT_ID}/workspace"
+    fi
     mkdir -p "$EFS_WORKSPACE" "$EFS_WORKSPACE/memory" "$EFS_WORKSPACE/skills"
     WORKSPACE="$EFS_WORKSPACE"
     export OPENCLAW_WORKSPACE="$WORKSPACE"
     EFS_MODE=true
-    echo "[entrypoint] EFS mode: workspace=${WORKSPACE}"
+    echo "[entrypoint] EFS mode: workspace=${WORKSPACE} (access_point=${EFS_ACCESS_POINT:-false})"
 
     # Bootstrap from S3 if this employee's EFS directory is empty (first start)
     if [ -z "$(ls -A "$EFS_WORKSPACE" 2>/dev/null)" ]; then
@@ -84,6 +94,18 @@ echo "$BASE_TENANT_ID" > /tmp/base_tenant_id
 OPENCLAW_CONFIG_DIR="$HOME/.openclaw"
 mkdir -p "$OPENCLAW_CONFIG_DIR"
 
+# In EFS mode, the OpenClaw Gateway reads its workspace from the default path
+# ($HOME/.openclaw/workspace), NOT from OPENCLAW_WORKSPACE. The assembled SOUL/memory
+# live on the persistent EFS workspace ($WORKSPACE). Symlink the Gateway's default
+# workspace path to the EFS workspace so the Gateway (and thus the Discord/IM path,
+# which talks to the Gateway directly and never hits server.py) reads the assembled
+# SOUL + persists memory durably on EFS across restarts.
+if [ "$EFS_MODE" = "true" ] && [ "$WORKSPACE" != "$OPENCLAW_CONFIG_DIR/workspace" ]; then
+    rm -rf "$OPENCLAW_CONFIG_DIR/workspace" 2>/dev/null
+    ln -sfn "$WORKSPACE" "$OPENCLAW_CONFIG_DIR/workspace"
+    echo "[entrypoint] Gateway workspace symlinked to EFS: $OPENCLAW_CONFIG_DIR/workspace -> $WORKSPACE"
+fi
+
 # Generate a random gateway token for this container instance
 # This token is stored in SSM so the admin console proxy can inject it
 GATEWAY_TOKEN=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
@@ -111,9 +133,20 @@ fi
 # Only runs if SHARED_AGENT_ID or SESSION_ID is set (i.e., we know the employee).
 # =============================================================================
 if [ "$EFS_MODE" = "true" ] || [ -n "${SHARED_AGENT_ID:-}" ]; then
-    # Quick S3 sync to get latest personal SOUL + workspace files before assembly
-    aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" \
-        --quiet --region "$AWS_REGION" 2>/dev/null || true
+    # Quick S3 sync to get latest personal SOUL + workspace files before assembly.
+    # In EFS mode the EFS copy is authoritative for memory/user-owned files (admin
+    # edits land there directly, and the container's own memory writes persist there).
+    # S3 is only the initial seed, so exclude those files to avoid clobbering EFS with
+    # a stale S3 version on every cold start.
+    if [ "$EFS_MODE" = "true" ]; then
+        aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" \
+            --exclude "MEMORY.md" --exclude "memory/*" --exclude "USER.md" \
+            --exclude "PERSONAL_SOUL.md" --exclude "HEARTBEAT.md" --exclude "output/*" \
+            --quiet --region "$AWS_REGION" 2>/dev/null || true
+    else
+        aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" \
+            --quiet --region "$AWS_REGION" 2>/dev/null || true
+    fi
     # Run workspace_assembler synchronously (will get SOUL from S3 + assemble)
     if [ -f "/app/workspace_assembler.py" ] && [ "$BASE_TENANT_ID" != "unknown" ]; then
         timeout 25 python3 /app/workspace_assembler.py \
@@ -154,6 +187,15 @@ dc_token = os.environ.get('DISCORD_BOT_TOKEN', '')
 if dc_token:
     c['channels'].setdefault('discord', {})
     c['channels']['discord']['token'] = dc_token
+    # Pre-authorize Discord user IDs via allowFrom so approved users skip the
+    # interactive DM pairing flow. DISCORD_ALLOW_FROM is a comma-separated list
+    # of Discord user IDs (per-employee, set on the ECS task definition).
+    allow_raw = os.environ.get('DISCORD_ALLOW_FROM', '').strip()
+    if allow_raw:
+        allow = [x.strip() for x in allow_raw.split(',') if x.strip()]
+        if allow:
+            c['channels']['discord']['allowFrom'] = allow
+            print('[entrypoint] Discord allowFrom pre-authorized: %d id(s)' % len(allow))
     print('[entrypoint] Discord bot token injected')
 
 with open(config_path, 'w') as f:
@@ -295,7 +337,16 @@ echo "[entrypoint] server.py PID=${SERVER_PID}"
 # =============================================================================
 (
     echo "[bg] Pulling workspace from S3..."
-    aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" --exclude "output/*" --quiet 2>/dev/null || true
+    # In EFS mode, EFS is authoritative for memory/user files — exclude them so the
+    # S3 seed doesn't clobber admin edits or the container's own persisted memory.
+    if [ "$EFS_MODE" = "true" ]; then
+        aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" \
+            --exclude "MEMORY.md" --exclude "memory/*" --exclude "USER.md" \
+            --exclude "PERSONAL_SOUL.md" --exclude "HEARTBEAT.md" --exclude "output/*" \
+            --quiet 2>/dev/null || true
+    else
+        aws s3 sync "${S3_BASE}/workspace/" "$WORKSPACE/" --exclude "output/*" --quiet 2>/dev/null || true
+    fi
 
     # Detect shared agent: if tenant_id starts with "shared_" or matches a shared agent pattern
     # The tenant router sets SHARED_AGENT_ID env var for shared agents

--- a/enterprise/agent-container/openclaw.json
+++ b/enterprise/agent-container/openclaw.json
@@ -39,7 +39,7 @@
   "gateway": {
     "port": 18789,
     "mode": "local",
-    "bind": "lan",
+    "bind": "loopback",
     "auth": {
       "mode": "none"
     },


### PR DESCRIPTION
## Summary

Fixes the always-on (ECS Fargate) agent path end-to-end so Discord/IM works **and** the admin console can manage an employee agent's SOUL/memory on EFS. Verified live: admin console edited an employee's `MEMORY.md` → EFS → the running container read it → the agent correctly recalled the value, running on the correct per-tier model.

## Root causes fixed

1. **Gateway wouldn't start** — `openclaw.json` had `gateway.bind: lan` + `auth: none`; OpenClaw refuses to bind to lan without auth, so the Gateway (which hosts the Discord/IM client) exited and IM silently never connected. → `bind: loopback`.

2. **Discord/IM path couldn't see the assembled SOUL** — the IM client lives in the Gateway, which reads `~/.openclaw/workspace` and never hits `server.py` (where the SOUL mirror used to run). → entrypoint symlinks `~/.openclaw/workspace` → the EFS workspace.

3. **Cold boot clobbered admin edits** — EFS-mode containers re-synced the S3 seed over EFS on every start, overwriting admin-edited memory/user files. → exclude `MEMORY.md`, `memory/*`, `USER.md`, `PERSONAL_SOUL.md`, `HEARTBEAT.md` from the EFS-mode seed sync.

4. **Interactive DM pairing required for every user** → entrypoint injects `allowFrom` from `DISCORD_ALLOW_FROM` to pre-authorize user ids.

5. **EFS access-point double path-prefix** — the access point root is already scoped to `/{employee}`, but the entrypoint appended the employee id again (`/emp-x/emp-x/workspace`), diverging from the admin console's root-mounted `/emp-x/workspace` view, so admin edits never reached the container. → when `EFS_ACCESS_POINT=true`, use `/mnt/efs/workspace` (no employee prefix); `start` injects that flag when an access point is mounted.

6. **`reload` regressed the model** — it re-registered the task def from base defaults (standard tier / wrong model). → `reload` now resolves the employee's tier like `start` does.

## Changes

- `agent-container/openclaw.json` — gateway `bind: lan` → `loopback`.
- `agent-container/entrypoint.sh` — EFS workspace symlink; access-point-aware path; EFS-mode seed-sync excludes; Discord `allowFrom` injection.
- `admin-console/server/routers/admin_always_on.py` — `start` injects `EFS_ACCESS_POINT`; `reload` resolves tier.
- `admin-console/server/s3ops.py` — route personal-workspace reads/writes to the EFS mount for always-on employees; shared layers stay on S3.

## Notes / follow-ups

- Prefer `start` over `reload` for always-on agents: `reload`'s EFS volume does not yet mount the access point, so it falls back to the root-mount path layout. Unifying this is a follow-up.
- No secrets, account IDs, or resource IDs are hardcoded — all read from env/config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)