### PR TITLE
fix: react-router CVE bump + s3ops path-traversal fix

### DIFF
--- a/enterprise/admin-console/package-lock.json
+++ b/enterprise/admin-console/package-lock.json
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3368,12 +3368,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/enterprise/admin-console/server/s3ops.py
+++ b/enterprise/admin-console/server/s3ops.py
@@ -4,6 +4,7 @@ Centralizes all S3 access with proper error handling and caching.
 """
 import os
 import json
+import re
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -60,13 +61,29 @@ def _efs_path_for_key(key: str) -> Optional[str]:
     # Only personal workspace keys; shared layers (_shared/...) always live on S3.
     if not rest.startswith("workspace/"):
         return None
-    if not emp_id.startswith("emp-"):
+    # Strict allowlist sanitization to prevent path traversal: every path segment of
+    # the key must match a safe pattern (no "..", no absolute parts, no NUL or other
+    # separators). This rejects the input outright rather than relying on a
+    # post-join realpath check, so the value reaching os.path.join is constrained.
+    if not re.fullmatch(r"emp-[a-z0-9-]+", emp_id):
         return None
+    segments = rest.split("/")
+    for seg in segments:
+        if seg in ("", ".", "..") or not re.fullmatch(r"[A-Za-z0-9._-]+", seg):
+            return None
     if not _is_always_on_employee(emp_id):
         return None
-    if not os.path.isdir(os.path.join(EFS_ROOT, emp_id, "workspace")):
+    workspace_root = os.path.join(EFS_ROOT, emp_id, "workspace")
+    if not os.path.isdir(workspace_root):
         return None
-    return os.path.join(EFS_ROOT, emp_id, rest)
+    # Build the target from sanitized segments only. Defense-in-depth: also confirm
+    # the resolved real path stays within the employee workspace.
+    target = os.path.join(EFS_ROOT, emp_id, *segments)
+    real_root = os.path.realpath(workspace_root)
+    real_target = os.path.realpath(target)
+    if real_target != real_root and not real_target.startswith(real_root + os.sep):
+        return None
+    return target
 
 
 def _client():


### PR DESCRIPTION
Two related hardening changes, batched into one PR to keep branch count low.

## 1. react-router 7.13.1 → 7.17.0 (admin-console)
Clears 6 Dependabot alerts (React Router single-fetch DoS, CVE-2026-34077 et al). Lockfile-only; `^7.0.0` already permits it. App uses Declarative Mode (`<BrowserRouter>`), which the advisories state is **not** affected — this clears alerts and keeps deps current. `npm run build` ✓, `npm audit` → 0.

## 2. s3ops path-traversal fix (py/path-injection — 4 high, from CodeQL on #149)
The EFS workspace redirect added in #149 built a filesystem path from a user-influenced S3 key, so `emp-x/workspace/../../etc/passwd` could escape the workspace on read/write.
- Strict emp_id allowlist (`re.fullmatch(r"emp-[a-z0-9-]+")`).
- `realpath()` the target and require it stay within the employee workspace.
- Verified: 6 traversal payloads blocked; legit paths + `_shared/*` S3 routing unaffected.

Deployed to the live admin-console and verified before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)